### PR TITLE
fix: Use of TypeUtils to fix getRepositoryForEntity method

### DIFF
--- a/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
+++ b/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
@@ -160,12 +160,10 @@ public class SpringJPASteps {
     public <E> CrudRepository<E, ?> getRepositoryForEntity(Type type) {
         if (Types.rawTypeOf(type).isAnnotationPresent(Entity.class)) {
             return spring.applicationContext().getBeansOfType(CrudRepository.class).values()
-                    .stream()
-                    .map(bean -> (CrudRepository<E, ?>) bean)
-                    .filter(r -> {
-                        Type type0 = TypeUtils.unrollVariables(TypeUtils.getTypeArguments(r.getClass(), CrudRepository.class), CrudRepository.class.getTypeParameters()[0]);
-                        return type.equals(type0);
-                    }).findFirst().orElseThrow(() -> new AssertionError("there was no CrudRepository found for entity %s! If you don't need one in your app, you must create one in your tests!".formatted(type.getTypeName())));
+                .stream()
+                .map(bean -> (CrudRepository<E, ?>) bean)
+                .filter(r -> type.equals(TypeUtils.unrollVariables(TypeUtils.getTypeArguments(r.getClass(), CrudRepository.class), CrudRepository.class.getTypeParameters()[0])))
+                .findFirst().orElseThrow(() -> new AssertionError("there was no CrudRepository found for entity %s! If you don't need one in your app, you must create one in your tests!".formatted(type.getTypeName())));
         }
         throw new AssertionError(type + " is not an Entity!");
     }

--- a/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
+++ b/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
@@ -165,7 +165,7 @@ public class SpringJPASteps {
                     .filter(r -> {
                         Type type0 = TypeUtils.unrollVariables(TypeUtils.getTypeArguments(r.getClass(), CrudRepository.class), CrudRepository.class.getTypeParameters()[0]);
                         return type.equals(type0);
-                    }).findFirst().orElseThrow(() -> new AssertionError("type %s is not a CrudRepository!".formatted(type.getTypeName())));
+                    }).findFirst().orElseThrow(() -> new AssertionError("there was no CrudRepository found for entity %s! If you don't need one in your app, you must create one in your tests!".formatted(type.getTypeName())));
         }
         throw new AssertionError(type + " is not an Entity!");
     }


### PR DESCRIPTION
Currently, while using the sentence like "that the DeliveryEventEntity entities will contain:", we get the following error:
<img width="1237" alt="Capture d’écran 2022-01-24 à 16 32 09" src="https://user-images.githubusercontent.com/20739026/150813046-b89c4147-0769-409b-a280-f9b88c563187.png">

I fixed that the same way than getRepositoryForTable works, filtering on our CrudRepository classes. It now works on my local env.
