### PR TITLE
feat: added HttpInterceptor to rewrite url at the client level

### DIFF
--- a/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
+++ b/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.concurrent.ConcurrentException;
 import org.apache.commons.lang3.concurrent.ConcurrentInitializer;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.TimeToLive;
@@ -95,19 +96,22 @@ public class MockFaster {
         Matcher uri = match(path);
         if (uri.group(2) != null) {
             MOCKED_PATHS.add(uri.group(1) + "://" + uri.group(2));
-            return uri.group(3);
+            return remapAsMocked(uri);
         }
         return path;
     }
 
     public static String target(String path) {
         Matcher uri = match(path);
-        if (uri.group(2) != null) {
-            if (MOCKED_PATHS.contains(uri.group(1) + "://" + uri.group(2))) {
-                return url() + uri.group(3);
-            }
+        if (uri.group(2) != null && MOCKED_PATHS.contains(uri.group(1) + "://" + uri.group(2))) {
+            return url() + remapAsMocked(uri);
         }
         return path;
+    }
+
+    @NotNull
+    private static String remapAsMocked(Matcher uri) {
+        return "/_mocked/" + uri.group(1) + "/" + uri.group(2) + uri.group(3);
     }
 
     public static Integer localPort() {

--- a/tzatziki-http/README.md
+++ b/tzatziki-http/README.md
@@ -203,6 +203,13 @@ Then we receive:
   """
 ```
 
+#### URL remapping
+
+Each mocked host will be dynamically remapped on the local mockserver.
+This means that `http://backend/users` will actually be `http://localhost:{{mockserver.port}}/http/backend/users`
+
+Once you have created the mock, your calls will also be remapped, so that you can call `http://backend/users` and not the remapped url.
+
 #### Assert interactions
 
 You can assert that a defined mock has been interacted with, the same way you would do it with mockserver.

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -229,10 +229,18 @@ public class HttpSteps {
 
     public void send(String user, String path, Request request) {
         try {
-            objects.add("response", Response.fromResponse(request.send(as(user), target(objects.resolve(path)), objects)));
+            objects.add("response", Response.fromResponse(request.send(as(user), addHostIfMissing(target(objects.resolve(path))), objects)));
         } catch (Exception e) {
             throw new AssertionError(e.getMessage(), e);
         }
+    }
+
+    private String addHostIfMissing(String path) {
+        if (path.startsWith("/")) {
+            // the user didn't specify a host, we assume it's localhost on the default port
+            return "http://localhost:%s%s".formatted(objects.getOrDefault("local.port", 8080), path);
+        }
+        return path;
     }
 
     @Then(THAT + GUARD + "(" + A_USER + ")?" + CALLING + " (?:on )?" + QUOTED_CONTENT + " returns a status " + STATUS + "$")
@@ -273,7 +281,7 @@ public class HttpSteps {
     public void call(Guard guard, String user, Method method, String path) {
         guard.in(objects, () -> {
             try {
-                objects.add("response", Response.fromResponse(as(user).request(method.name(), target(objects.resolve(path)))));
+                objects.add("response", Response.fromResponse(as(user).request(method.name(), addHostIfMissing(target(objects.resolve(path))))));
             } catch (Exception e) {
                 throw new AssertionError(e.getMessage(), e);
             }

--- a/tzatziki-logback/pom.xml
+++ b/tzatziki-logback/pom.xml
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>io.semla</groupId>
             <artifactId>semla-logging</artifactId>
-            <version>1.1.5</version>
+            <version>1.1.6</version>
         </dependency>
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>6.4</version>
+            <version>7.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/tzatziki-spring/README.md
+++ b/tzatziki-spring/README.md
@@ -100,6 +100,36 @@ public class HelloController {
 
 and that you run your test again, it should now pass!
 
+## A few words about URL remapping
+
+Since we don't really want to have to specify the port of our local spring instance, this one is actually stored in a local variable as `local.port`. 
+This local port is automatically added to each url that doesn't specify a host. So when you call `/hello`, it actually calls `http://localhost:{{local.port}}/hello`. 
+
+This module will also intercept all the calls made by your WebClient and RestTemplate and dynamically remap the URL for the mocked ones.
+
+This mean that if in your code you have:
+```java
+restTemplate.getForObject(new URI("http://www.google.com"), String.class);
+//or
+webClient.get().uri(new URI("http://www.google.com")).retrieve().toEntity(String.class);
+```
+
+but that you have defined this mock:
+```gherkin
+  # we define a mock that will be remapped as http://localhost:{{mockserver.port}}/http/www.google.com
+  Given that calling "http://www.google.com" will return a status FORBIDDEN_403
+```
+
+Then the url actually called during your test will be `http://localhost:{{mockserver.port}}/http/www.google.com`.
+
+This behaviour can be disabled dynamically by setting:
+```java
+HttpInterceptor.disable();
+```
+
+If you wish to intercept requests for another client than the supported ones, 
+you can have a look at the `com.decathlon.tzatziki.spring.HttpInterceptor` code and write your own interceptor.
+
 ## Steps local to this library
 
 This library doesn't come with a lot of steps, but it will start your Spring automatically 

--- a/tzatziki-spring/README.md
+++ b/tzatziki-spring/README.md
@@ -107,7 +107,7 @@ This local port is automatically added to each url that doesn't specify a host. 
 
 This module will also intercept all the calls made by your WebClient and RestTemplate and dynamically remap the URL for the mocked ones.
 
-This mean that if in your code you have:
+This means that if in your code you have:
 ```java
 restTemplate.getForObject(new URI("http://www.google.com"), String.class);
 //or
@@ -120,9 +120,9 @@ but that you have defined this mock:
   Given that calling "http://www.google.com" will return a status FORBIDDEN_403
 ```
 
-Then the url actually called during your test will be `http://localhost:{{mockserver.port}}/http/www.google.com`.
+Then the url that will actually be called during your test is `http://localhost:{{mockserver.port}}/http/www.google.com`.
 
-This behaviour can be disabled dynamically by setting:
+This behaviour can be disabled dynamically by using:
 ```java
 HttpInterceptor.disable();
 ```

--- a/tzatziki-spring/pom.xml
+++ b/tzatziki-spring/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.9.5</version>
+            <version>1.9.7</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -68,6 +68,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
@@ -1,0 +1,111 @@
+package com.decathlon.tzatziki.spring;
+
+import com.decathlon.tzatziki.utils.Fields;
+import com.decathlon.tzatziki.utils.MockFaster;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.*;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.Function;
+
+@Aspect
+@Component
+@Slf4j
+public class HttpInterceptor {
+
+    private static boolean enabled = true;
+
+    public static void enable() {
+        enabled = true;
+    }
+
+    public static void disable() {
+        enabled = false;
+    }
+
+    @Around("@annotation(org.springframework.context.annotation.Bean)")
+    public Object beanCreation(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object bean = joinPoint.proceed();
+        if (bean instanceof RestTemplate restTemplate) {
+            ClientHttpRequestFactory requestFactory = Fields.getValue(restTemplate, "requestFactory");
+            Fields.setValue(restTemplate, "requestFactory", new ClientHttpRequestFactory() {
+                @SneakyThrows
+                @Override
+                public @NotNull
+                ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) throws IOException {
+                    return requestFactory.createRequest(remap(uri), httpMethod);
+                }
+            });
+            return restTemplate;
+        } else if (bean instanceof RestTemplateBuilder restTemplateBuilder) {
+            return restTemplateBuilder.additionalInterceptors(new ClientHttpRequestInterceptor() {
+                @Override
+                public @NotNull ClientHttpResponse intercept(
+                        @NotNull HttpRequest request,
+                        byte @NotNull [] body,
+                        @NotNull ClientHttpRequestExecution execution) throws IOException {
+                    HttpRequest proxiedHttpRequest = (HttpRequest) Proxy.newProxyInstance(
+                            request.getClass().getClassLoader(),
+                            new Class[]{HttpRequest.class},
+                            (proxy, method, args) -> switch (method.getName()) {
+                                case "getURI" -> remap(request.getURI());
+                                default -> method.invoke(request, args);
+                            });
+                    return execution.execute(proxiedHttpRequest, body);
+                }
+            });
+        } else if (bean instanceof WebClient webClient && bean.getClass().getName().equals("org.springframework.web.reactive.function.client.DefaultWebClient")) {
+            ExchangeFunction exchangeFunction = Fields.getValue(bean, "exchangeFunction");
+            ClientHttpConnector clientHttpConnector = Fields.getValue(exchangeFunction, "connector");
+            Fields.setValue(exchangeFunction, "connector", new ClientHttpConnector() {
+                @Override
+                @SneakyThrows
+                public @NotNull Mono<org.springframework.http.client.reactive.ClientHttpResponse> connect(
+                        @NotNull HttpMethod method,
+                        @NotNull URI uri,
+                        @NotNull Function<? super org.springframework.http.client.reactive.ClientHttpRequest, Mono<Void>> requestCallback) {
+                    return clientHttpConnector.connect(method, remap(uri), requestCallback);
+                }
+            });
+            return webClient;
+        } else if (bean instanceof WebClient.Builder builder) {
+            return builder.filter((request, next) -> {
+                ClientRequest proxiedClientRequest = (ClientRequest) Proxy.newProxyInstance(
+                        ClientRequest.class.getClassLoader(),
+                        new Class[]{ClientRequest.class},
+                        (proxy, method, args) -> switch (method.getName()) {
+                            case "url" -> remap(request.url());
+                            default -> method.invoke(request, args);
+                        });
+                return next.exchange(proxiedClientRequest);
+            });
+        }
+        return bean;
+    }
+
+    @NotNull
+    private URI remap(URI uri) throws URISyntaxException {
+        if (enabled) {
+            return new URI(MockFaster.target(uri.toString()));
+        }
+        return uri;
+    }
+}

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
@@ -45,7 +45,7 @@ public class SpringSteps {
 
     @Before
     public void before() {
-        RestAssured.port = localServerPort;
+        objects.add("local.port", localServerPort);
         if (applicationContext != null) {
             we_clear_all_the_caches(always());
         }

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/app/TestApplication.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/app/TestApplication.java
@@ -2,13 +2,37 @@ package com.decathlon.tzatziki.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.decathlon")
 @EnableCaching
 public class TestApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(TestApplication.class, args);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public RestTemplateBuilder restTemplateBuilder() {
+        return new RestTemplateBuilder();
+    }
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.create();
     }
 }

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/app/api/HelloController.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/app/api/HelloController.java
@@ -1,14 +1,58 @@
 package com.decathlon.tzatziki.app.api;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static com.decathlon.tzatziki.utils.Unchecked.unchecked;
 
 @RestController
 public class HelloController {
 
+    private static final URI remoteBackend = unchecked(() -> new URI("http://backend/greeting"));
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    private WebClient webClient;
+
+    @Autowired
+    private WebClient.Builder webClientBuilder;
+
     @GetMapping("/hello")
     public ResponseEntity<String> hello() {
         return ResponseEntity.ok("Hello world!");
+    }
+
+    @GetMapping("/rest-template-remote-hello")
+    public ResponseEntity<String> restTemplateRemoteHello() throws URISyntaxException {
+        return ResponseEntity.ok(restTemplate.getForObject(remoteBackend, String.class));
+    }
+
+    @GetMapping("/rest-template-builder-remote-hello")
+    public ResponseEntity<String> restTemplateBuilderRemoteHello() throws URISyntaxException {
+        return ResponseEntity.ok(restTemplateBuilder.build().getForObject(remoteBackend, String.class));
+    }
+
+    @GetMapping("/web-client-remote-hello")
+    public Mono<ResponseEntity<String>> webClientRemoteHello() throws URISyntaxException {
+        return webClient.get().uri(remoteBackend).retrieve().toEntity(String.class);
+    }
+
+    @GetMapping("/web-client-builder-remote-hello")
+    public Mono<ResponseEntity<String>> webClientBuilderRemoteHello() throws URISyntaxException {
+        return webClientBuilder.build().get().uri(remoteBackend).retrieve().toEntity(String.class);
     }
 }

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
@@ -1,6 +1,9 @@
 package com.decathlon.tzatziki.steps;
 
 import com.decathlon.tzatziki.app.TestApplication;
+import com.decathlon.tzatziki.spring.HttpInterceptor;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
 import io.cucumber.spring.CucumberContextConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,5 +23,15 @@ public class TestApplicationSteps {
 
         public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
         }
+    }
+
+    @Before
+    public void before() {
+        HttpInterceptor.enable();
+    }
+
+    @Then("if we disable the HttpInterceptor")
+    public void if_we_disable_the_http_interceptor() {
+        HttpInterceptor.disable();
     }
 }

--- a/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
+++ b/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
@@ -41,3 +41,9 @@ Feature: to interact with a spring boot service
       | /rest-template-builder-remote-hello |
       | /web-client-remote-hello            |
       | /web-client-builder-remote-hello    |
+
+  Scenario: we can still reach the internet
+    When we call "http://www.google.com"
+    Then we receive a status 200
+    But if calling "http://www.google.com" will return a status FORBIDDEN_403
+    Then calling "http://www.google.com" returns a status FORBIDDEN_403

--- a/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
+++ b/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
@@ -28,3 +28,16 @@ Feature: to interact with a spring boot service
       key:
         - value1
       """
+
+  Scenario Template: we can mock a real url
+    Given that calling "http://backend/greeting" will return "Hello from another backend"
+    Then calling "<endpoint>" returns "Hello from another backend"
+    But if we disable the HttpInterceptor
+    Then calling "<endpoint>" returns a status 500
+
+    Examples:
+      | endpoint                            |
+      | /rest-template-remote-hello         |
+      | /rest-template-builder-remote-hello |
+      | /web-client-remote-hello            |
+      | /web-client-builder-remote-hello    |


### PR DESCRIPTION
following https://github.com/Decathlon/tzatziki/discussions/17

This new HttpInterceptor class can intercept and rewrite the urls before any call from a RestTemplate or WebClient. 
That way we don't need to override the production urls in the test config.
If a mock exists, the url will be transparently replaced by the mock url and port.
(we now remap the mocks following this pattern to avoid collisions `/_mocked/{protocol}/{host}/{path}`)

This PR also fixes the local port glitch mentioned in the discussion.