### PR TITLE
feat: extract data from repository

### DIFF
--- a/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
+++ b/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
@@ -24,6 +24,7 @@ import static com.decathlon.tzatziki.utils.Guard.GUARD;
 import static com.decathlon.tzatziki.utils.InsertionMode.INSERTION_MODE;
 import static com.decathlon.tzatziki.utils.Patterns.THAT;
 import static com.decathlon.tzatziki.utils.Patterns.TYPE;
+import static com.decathlon.tzatziki.utils.Patterns.VARIABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpringJPASteps {
@@ -104,6 +105,16 @@ public class SpringJPASteps {
         the_repository_contains_nothing(guard, getRepositoryForEntity(type));
     }
 
+    @Then(THAT + GUARD + VARIABLE + " is the ([^ ]+) table content$")
+    public void add_table_content_to_variable(Guard guard, String name, String table) {
+        add_repository_content_to_variable(guard, name, getRepositoryForTable(table));
+    }
+
+    @Then(THAT + GUARD + VARIABLE + " is the " + TYPE + " entities$")
+    public void add_entities_to_variable(Guard guard, String name, Type type) {
+        add_repository_content_to_variable(guard, name, getRepositoryForEntity(type));
+    }
+
     private void the_repository_contains_nothing(Guard guard, CrudRepository<Object, ?> repositoryOfEntity) {
         guard.in(objects, () -> awaitUntilAsserted(() -> assertThat(repositoryOfEntity.count()).isZero()));
     }
@@ -136,6 +147,10 @@ public class SpringJPASteps {
                 comparison.compare(actualEntities, expectedEntities);
             });
         });
+    }
+
+    public <E> void add_repository_content_to_variable(Guard guard, String name, CrudRepository<E, ?> repository) {
+        guard.in(objects, () -> objects.add(name, StreamSupport.stream(repository.findAll().spliterator(), false).toList()));
     }
 
     @SuppressWarnings("unchecked")

--- a/tzatziki-spring-jpa/src/test/resources/com/decathlon/tzatziki/steps/spring-jpa.feature
+++ b/tzatziki-spring-jpa/src/test/resources/com/decathlon/tzatziki/steps/spring-jpa.feature
@@ -165,3 +165,23 @@ Feature: to interact with a spring boot service having a persistence layer
     Then the groups table contains:
       | id | name |
       | 1  | Sith |
+
+  Scenario: we can get a table content
+    Given that the users table will contain only:
+      | id | firstName | lastName |
+      | 1  | Darth     | Vader    |
+      | 2  | Han       | Solo     |
+    Then usersTableContent is the users table content
+    And usersTableContent.size is equal to 2
+    And usersTableContent[0].id is equal to 1
+    And usersTableContent[1].id is equal to 2
+
+  Scenario: we can get entities
+    Given that the User entities will contain only:
+      | id | firstName | lastName |
+      | 1  | Darth     | Vader    |
+      | 2  | Han       | Solo     |
+    Then userEntities is the User entities
+    And userEntities.size is equal to 2
+    And userEntities[0].id is equal to 1
+    And userEntities[1].id is equal to 2


### PR DESCRIPTION
When inserting data into tables where ids are auto generated and that I needed to link, I found no way of getting the value that was actually inserted in the DB. Either for testing DB triggers or low level transformations, I believe fetching data from the repositories is a common enough need to add this PR to the library. It simply does a findAll and store the content in a var. It follows ObjectSteps and SpringJPASteps naming conventions as close as possible.