### PR TITLE
fix: Issue when a null is in a DataTable

### DIFF
--- a/mockfaster/pom.xml
+++ b/mockfaster/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tzatziki-parent</artifactId>
         <groupId>com.decathlon.tzatziki</groupId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-common</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.decathlon.tzatziki</groupId>
     <artifactId>tzatziki-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     <modules>
         <module>tzatziki-common</module>
         <module>tzatziki-core</module>

--- a/tzatziki-common/pom.xml
+++ b/tzatziki-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tzatziki-parent</artifactId>
         <groupId>com.decathlon.tzatziki</groupId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tzatziki-common</artifactId>

--- a/tzatziki-core/pom.xml
+++ b/tzatziki-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.decathlon.tzatziki</groupId>
         <artifactId>tzatziki-parent</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tzatziki-core</artifactId>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-common</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
+++ b/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
@@ -1,64 +1,11 @@
 package com.decathlon.tzatziki.steps;
 
-import static com.decathlon.tzatziki.steps.DynamicTransformers.register;
-import static com.decathlon.tzatziki.utils.Comparison.IS_COMPARED_TO;
-import static com.decathlon.tzatziki.utils.Fields.*;
-import static com.decathlon.tzatziki.utils.Guard.GUARD;
-import static com.decathlon.tzatziki.utils.Methods.findMethod;
-import static com.decathlon.tzatziki.utils.Methods.invoke;
-import static com.decathlon.tzatziki.utils.Patterns.*;
-import static com.decathlon.tzatziki.utils.Time.TIME;
-import static com.decathlon.tzatziki.utils.Unchecked.unchecked;
-import static java.net.URLDecoder.decode;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Objects.requireNonNull;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.joining;
-import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Proxy;
-import java.lang.reflect.Type;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-
-import com.decathlon.tzatziki.utils.Comparison;
-import com.decathlon.tzatziki.utils.Env;
-import com.decathlon.tzatziki.utils.Guard;
-import com.decathlon.tzatziki.utils.Mapper;
-import com.decathlon.tzatziki.utils.Time;
-import com.decathlon.tzatziki.utils.TypeParser;
-import com.decathlon.tzatziki.utils.Types;
+import com.decathlon.tzatziki.utils.*;
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.google.common.base.Splitter;
-
 import edu.utexas.tacc.MathHelper;
 import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.eventbus.EventBus;
@@ -75,6 +22,44 @@ import io.cucumber.messages.types.TableRow;
 import io.cucumber.plugin.event.TestSourceParsed;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.decathlon.tzatziki.steps.DynamicTransformers.register;
+import static com.decathlon.tzatziki.utils.Comparison.IS_COMPARED_TO;
+import static com.decathlon.tzatziki.utils.Fields.*;
+import static com.decathlon.tzatziki.utils.Guard.GUARD;
+import static com.decathlon.tzatziki.utils.Methods.findMethod;
+import static com.decathlon.tzatziki.utils.Methods.invoke;
+import static com.decathlon.tzatziki.utils.Patterns.*;
+import static com.decathlon.tzatziki.utils.Time.TIME;
+import static com.decathlon.tzatziki.utils.Unchecked.unchecked;
+import static java.net.URLDecoder.decode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.joining;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unchecked")
 @Slf4j

--- a/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
+++ b/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
@@ -309,7 +309,7 @@ public class ObjectSteps {
                     .<String, String>toMaps((DataTable) content, String.class, String.class)
                     .stream()
                     .map(map -> map.entrySet().stream().collect(HashMap<String, Object>::new,
-                            (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll))
+                            (newMap, entry) -> newMap.put(entry.getKey(), entry.getValue()), HashMap::putAll))
                     .map(ObjectSteps::dotToMap)
                     .collect(Collectors.toList()));
         } else if (content instanceof DocString) {

--- a/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
+++ b/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
@@ -309,7 +309,7 @@ public class ObjectSteps {
                     .<String, String>toMaps((DataTable) content, String.class, String.class)
                     .stream()
                     .map(map -> map.entrySet().stream().collect(HashMap<String, Object>::new,
-                            (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll))
+                            (map, entry) -> map.put(entry.getKey(), entry.getValue()), HashMap::putAll))
                     .map(ObjectSteps::dotToMap)
                     .collect(Collectors.toList()));
         } else if (content instanceof DocString) {

--- a/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
+++ b/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
@@ -1,11 +1,64 @@
 package com.decathlon.tzatziki.steps;
 
-import com.decathlon.tzatziki.utils.*;
+import static com.decathlon.tzatziki.steps.DynamicTransformers.register;
+import static com.decathlon.tzatziki.utils.Comparison.IS_COMPARED_TO;
+import static com.decathlon.tzatziki.utils.Fields.*;
+import static com.decathlon.tzatziki.utils.Guard.GUARD;
+import static com.decathlon.tzatziki.utils.Methods.findMethod;
+import static com.decathlon.tzatziki.utils.Methods.invoke;
+import static com.decathlon.tzatziki.utils.Patterns.*;
+import static com.decathlon.tzatziki.utils.Time.TIME;
+import static com.decathlon.tzatziki.utils.Unchecked.unchecked;
+import static java.net.URLDecoder.decode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.joining;
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+
+import com.decathlon.tzatziki.utils.Comparison;
+import com.decathlon.tzatziki.utils.Env;
+import com.decathlon.tzatziki.utils.Guard;
+import com.decathlon.tzatziki.utils.Mapper;
+import com.decathlon.tzatziki.utils.Time;
+import com.decathlon.tzatziki.utils.TypeParser;
+import com.decathlon.tzatziki.utils.Types;
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.google.common.base.Splitter;
+
 import edu.utexas.tacc.MathHelper;
 import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.eventbus.EventBus;
@@ -22,45 +75,6 @@ import io.cucumber.messages.types.TableRow;
 import io.cucumber.plugin.event.TestSourceParsed;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Proxy;
-import java.lang.reflect.Type;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import static com.decathlon.tzatziki.steps.DynamicTransformers.register;
-import static com.decathlon.tzatziki.utils.Comparison.IS_COMPARED_TO;
-import static com.decathlon.tzatziki.utils.Fields.*;
-import static com.decathlon.tzatziki.utils.Guard.GUARD;
-import static com.decathlon.tzatziki.utils.Methods.findMethod;
-import static com.decathlon.tzatziki.utils.Methods.invoke;
-import static com.decathlon.tzatziki.utils.Patterns.*;
-import static com.decathlon.tzatziki.utils.Time.TIME;
-import static com.decathlon.tzatziki.utils.Unchecked.unchecked;
-import static java.net.URLDecoder.decode;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Objects.requireNonNull;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toMap;
-import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unchecked")
 @Slf4j
@@ -309,7 +323,8 @@ public class ObjectSteps {
                     .getTableConverter()
                     .<String, String>toMaps((DataTable) content, String.class, String.class)
                     .stream()
-                    .map(map -> map.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> resolve(e.getValue()))))
+                    .map(map -> map.entrySet().stream().collect(HashMap<String, Object>::new,
+                            (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll))
                     .map(ObjectSteps::dotToMap)
                     .collect(Collectors.toList()));
         } else if (content instanceof DocString) {

--- a/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
+++ b/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
@@ -325,12 +325,17 @@ Feature: to interact with objects in the context
     """
 
   Scenario: testing a null field of a Datatable
-    Given that users is:
+    Given that bob is:
       | id | name |
       | 1  |      |
     Then bob contains:
       | id | name    |
       | 1  | ?isNull |
+    And bob contains:
+    """yml
+    id: 1
+    name: ?isNull
+    """
 
   Scenario: we can compare a serialized Java Array String that starts with a [ but is actually not a Json document without breaking the Mapper
     Given that content is a Map:

--- a/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
+++ b/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
@@ -324,6 +324,14 @@ Feature: to interact with objects in the context
     score: ?isNull
     """
 
+  Scenario: testing a null field of a Datatable
+    Given that users is:
+      | id | name |
+      | 1  |      |
+    Then bob contains:
+      | id | name    |
+      | 1  | ?isNull |
+
   Scenario: we can compare a serialized Java Array String that starts with a [ but is actually not a Json document without breaking the Mapper
     Given that content is a Map:
       """yml

--- a/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
+++ b/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
@@ -324,18 +324,15 @@ Feature: to interact with objects in the context
     score: ?isNull
     """
 
-  Scenario: testing a null field of a Datatable
-    Given that bob is:
+  Scenario: testing a null field of a table
+    Given that users is:
       | id | name |
       | 1  |      |
-    Then bob contains:
+    Then users contains:
       | id | name    |
       | 1  | ?isNull |
-    And bob contains:
-    """yml
-    id: 1
-    name: ?isNull
-    """
+    And users[0].id is equal to 1
+    And users[0].name is equal to null
 
   Scenario: we can compare a serialized Java Array String that starts with a [ but is actually not a Json document without breaking the Mapper
     Given that content is a Map:

--- a/tzatziki-http/pom.xml
+++ b/tzatziki-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.decathlon.tzatziki</groupId>
         <artifactId>tzatziki-parent</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tzatziki-http</artifactId>
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-core</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-logback</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>mockfaster</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/tzatziki-logback/pom.xml
+++ b/tzatziki-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.decathlon.tzatziki</groupId>
         <artifactId>tzatziki-parent</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tzatziki-logback</artifactId>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-core</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>io.semla</groupId>

--- a/tzatziki-spring-jpa/pom.xml
+++ b/tzatziki-spring-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.decathlon.tzatziki</groupId>
         <artifactId>tzatziki-parent</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tzatziki-spring-jpa</artifactId>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-spring</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/tzatziki-spring-kafka/pom.xml
+++ b/tzatziki-spring-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tzatziki-parent</artifactId>
         <groupId>com.decathlon.tzatziki</groupId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-spring</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/tzatziki-spring/pom.xml
+++ b/tzatziki-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.decathlon.tzatziki</groupId>
         <artifactId>tzatziki-parent</artifactId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tzatziki-spring</artifactId>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-http</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.cucumber</groupId>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-logback</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.cucumber</groupId>

--- a/tzatziki-testng/pom.xml
+++ b/tzatziki-testng/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tzatziki-parent</artifactId>
         <groupId>com.decathlon.tzatziki</groupId>
-        <version>1.0.11</version>
+        <version>1.0.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-core</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>
             <artifactId>tzatziki-logback</artifactId>
-            <version>1.0.11</version>
+            <version>1.0.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
When collecting the values of a Datatable which contains null values, the `ObjectSteps#resolve` method throws a NullPointerException

Known bug from jdk https://bugs.openjdk.java.net/browse/JDK-8148463