### PR TITLE
fix: regression on resolve object in DataTable

### DIFF
--- a/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
+++ b/tzatziki-core/src/main/java/com/decathlon/tzatziki/steps/ObjectSteps.java
@@ -309,7 +309,7 @@ public class ObjectSteps {
                     .<String, String>toMaps((DataTable) content, String.class, String.class)
                     .stream()
                     .map(map -> map.entrySet().stream().collect(HashMap<String, Object>::new,
-                            (newMap, entry) -> newMap.put(entry.getKey(), entry.getValue()), HashMap::putAll))
+                            (newMap, entry) -> newMap.put(entry.getKey(), resolve(entry.getValue())), HashMap::putAll))
                     .map(ObjectSteps::dotToMap)
                     .collect(Collectors.toList()));
         } else if (content instanceof DocString) {

--- a/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
+++ b/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
@@ -334,6 +334,18 @@ Feature: to interact with objects in the context
     And users[0].id is equal to 1
     And users[0].name is equal to null
 
+  Scenario: we can compare json objects in table
+    * details is a Map:
+      """
+        {"key":"value"}
+      """
+    Given that users is:
+      | id | detail          |
+      | 1  | {"key":"value"} |
+    Then users contains:
+      | id | detail      |
+      | 1  | {{details}} |
+
   Scenario: we can compare a serialized Java Array String that starts with a [ but is actually not a Json document without breaking the Mapper
     Given that content is a Map:
       """yml


### PR DESCRIPTION
regression introduced in https://github.com/Decathlon/tzatziki/pull/31 (I accidently removed the `resolve` part in the `.put`)