### PR TITLE
fix: contains exactly comparison pattern

### DIFF
--- a/tzatziki-common/src/main/java/com/decathlon/tzatziki/utils/Comparison.java
+++ b/tzatziki-common/src/main/java/com/decathlon/tzatziki/utils/Comparison.java
@@ -7,7 +7,7 @@ import java.util.stream.Stream;
 public enum Comparison {
 
     EQUALS(Asserts::equalsInAnyOrder, "is equal to", "=="),
-    IS_EXACTLY(Asserts::equalsInOrder, "is exactly", "exactly"),
+    IS_EXACTLY(Asserts::equalsInOrder, "is exactly", "contains? exactly", "exactly"),
     CONTAINS(Asserts::contains, "contains?", "contains? at least", "at least"),
     CONTAINS_IN_ORDER(Asserts::containsInOrder, "contains? in order", "contains? at least and in order", "at least and in order", "in order"),
     CONTAINS_ONLY(Asserts::containsOnly, "contains? only", "only"),

--- a/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
+++ b/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
@@ -81,6 +81,7 @@ Feature: to interact with objects in the context
       - value2
       """
     And map.parameters.toString contains exactly "[value1, value2]"
+    And it is not true that map.parameters.toString contains exactly "[value1]"
     And map.parameters contains:
       """yml
       - value1

--- a/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
+++ b/tzatziki-core/src/test/resources/com/decathlon/tzatziki/steps/objects.feature
@@ -80,8 +80,8 @@ Feature: to interact with objects in the context
       - value1
       - value2
       """
-    And map.parameters.toString contains exactly "[value1, value2]"
-    And it is not true that map.parameters.toString contains exactly "[value1]"
+    And map.parameters contains exactly "[value1, value2]"
+    And it is not true that map.parameters contains exactly "[value1]"
     And map.parameters contains:
       """yml
       - value1


### PR DESCRIPTION
Comparison pattern `contains? exactly` from https://github.com/Decathlon/tzatziki/blob/5cae3967c28c744e37b03c95d252f37dd0908c47/tzatziki-common/src/main/java/com/decathlon/tzatziki/utils/Comparison.java#L16 is not a known `title` amongst the `Comparison` enum members. It is therefore by default parsed as the pattern `contains?`. I don't think it should and should be treated as the `exactly` pattern.

## Warning
this change presents a slight breaking change that could affect some users that would have used this pattern instead of the more permissive `contains`