### PR TITLE
fix: spring cache comparison syntax and add comparison variations

### DIFF
--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
@@ -1,5 +1,6 @@
 package com.decathlon.tzatziki.steps;
 
+import com.decathlon.tzatziki.utils.Comparison;
 import com.decathlon.tzatziki.utils.Guard;
 import com.decathlon.tzatziki.utils.JacksonMapper;
 import com.decathlon.tzatziki.utils.Mapper;
@@ -14,12 +15,13 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationContext;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-import static com.decathlon.tzatziki.utils.Asserts.equalsInAnyOrder;
+import static com.decathlon.tzatziki.utils.Comparison.COMPARING_WITH;
 import static com.decathlon.tzatziki.utils.Guard.GUARD;
 import static com.decathlon.tzatziki.utils.Guard.always;
 import static com.decathlon.tzatziki.utils.Patterns.*;
@@ -82,11 +84,15 @@ public class SpringSteps {
         });
     }
 
-    @Then(THAT + GUARD + "the cache " + VARIABLE + " contains:$")
-    public void theCacheContains(Guard guard, String cacheName, Object message) {
+    @Then(THAT + GUARD + "the cache " + VARIABLE + " contains" + COMPARING_WITH + "?:$")
+    public void theCacheContains(Guard guard, String cacheName, Comparison comparison, Object message) {
         Cache cache = getCache(cacheName);
-        guard.in(objects, () -> Mapper.<Map<String, Object>>read(this.objects.resolve(message))
-                .forEach((key, value) -> equalsInAnyOrder(cache.get(key, Object.class), value)));
+        guard.in(objects, () -> {
+            Map<String, Object> expected = Mapper.read(this.objects.resolve(message));
+            Map<String, Object> cacheMap = expected.keySet().stream().collect(HashMap::new, (m, k) -> m.put(k, cache.get(k, Object.class)), HashMap::putAll);
+            comparison.compare(cacheMap, expected);
+        });
+
     }
 
     @Given(THAT + GUARD + "the cache " + VARIABLE + " will contain:$")

--- a/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
+++ b/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
@@ -12,21 +12,35 @@ Feature: to interact with a spring boot service
     Given the cache nameOfTheCache will contain:
       """yml
       key:
-        - value
+        - field_a: value_a
+          field_b: value_b
       """
 
     Then the cache nameOfTheCache contains:
       """yml
       key:
-        - value
+        - field_a: value_a
+      """
+
+    Then the cache nameOfTheCache contains exactly:
+      """yml
+      key:
+        - field_a: value_a
+          field_b: value_b
+      """
+
+    And it is not true that the cache nameOfTheCache contains exactly:
+      """yml
+      key:
+        - field_a: value_a
       """
 
     And it is not true that the cache nameOfTheCache contains:
       """yml
       key1:
-        - value
+        - field_a: value_a
       key:
-        - value1
+        - field_a: value_b
       """
 
   Scenario Template: we can mock a real url


### PR DESCRIPTION
Fixes cache assertion semantic that don't line up with common Tzatziki behaviour for the given `contains` assertion since it does an `exactly` comparison. Extends the use of the assertion to allow for `exactly` and other comparisons.

## Warning
This fix is a breaking change for whoever expected the actual `the cache {} contains` guard to do an exact comparison.