### PR TITLE
fix: avoid NullPointerException in getRepositoryForTable if there is repositories with inheritance in the application

### DIFF
--- a/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
+++ b/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
@@ -176,9 +176,10 @@ public class SpringJPASteps {
                 .map(bean -> (CrudRepository<E, ?>) bean)
                 .filter(r -> {
                     Class<E> e = getEntityType(r);
-                    return (e.isAnnotationPresent(Table.class) && e.getAnnotation(Table.class).name().equals(table))
-                            || e.getSimpleName().equals(table)
-                            || toSnakeCase(e.getSimpleName()).equals(table);
+                    return e != null && (
+                            (e.isAnnotationPresent(Table.class) && e.getAnnotation(Table.class).name().equals(table))
+                                    || e.getSimpleName().equals(table)
+                                    || toSnakeCase(e.getSimpleName()).equals(table));
                 }).findFirst().orElseThrow(() -> new AssertionError(
                         "there was no CrudRepository found for table '%s'! If you don't need one in your app, you must create one in your tests!".formatted(table)
                 ));


### PR DESCRIPTION
Temporary fix to avoid exceptions thrown in getRepositoryForTable if the application contains repository with inheritance.

Related to https://github.com/Decathlon/tzatziki/issues/88#issuecomment-1259495390