### PR TITLE
fix: log assertions concurrent modification

### DIFF
--- a/tzatziki-logback/pom.xml
+++ b/tzatziki-logback/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.semla</groupId>
             <artifactId>semla-logging</artifactId>
-            <version>1.1.6</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>net.logstash.logback</groupId>

--- a/tzatziki-logback/src/main/java/com/decathlon/tzatziki/steps/LoggerSteps.java
+++ b/tzatziki-logback/src/main/java/com/decathlon/tzatziki/steps/LoggerSteps.java
@@ -16,10 +16,10 @@ import org.assertj.core.api.Condition;
 import org.assertj.core.api.ListAssert;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.IntFunction;
-import java.util.function.Predicate;
 
 import static com.decathlon.tzatziki.utils.Guard.GUARD;
 import static com.decathlon.tzatziki.utils.Patterns.*;
@@ -104,7 +104,7 @@ public class LoggerSteps {
 
     @Then(THAT + GUARD + "the logs are empty$")
     public void the_logs_are_empty(Guard guard) {
-        guard.in(objects, () -> assertThat(listAppender.logLines()).isEmpty());
+        guard.in(objects, () -> assertThat(List.of(listAppender.logLines().toArray(new String[0]))).isEmpty());
     }
 
     @Then(THAT + GUARD + "the logs are formatted in json$")
@@ -115,7 +115,7 @@ public class LoggerSteps {
     @Then(THAT + GUARD + "the logs" + Comparison.IS_COMPARED_TO + ":$")
     public void the_logs_contain(Guard guard, Comparison comparison, String sourceValue) {
         guard.in(objects, () -> comparison.compare(
-                listAppender.logLines(),
+                List.of(listAppender.logLines().toArray(new String[0])),
                 Mapper.readAsAListOf(objects.resolve(sourceValue), String.class)
         ));
     }
@@ -134,7 +134,7 @@ public class LoggerSteps {
                 }
             }, "match");
 
-            ListAssert<String> assertStump = assertThat(listAppender.logLines());
+            ListAssert<String> assertStump = assertThat(List.of(listAppender.logLines().toArray(new String[0])));
 
             Optional.ofNullable(verification)
                     .<IntFunction<ListAssert<String>>>map(v ->


### PR DESCRIPTION
This PR solves the issue #106 by delegating the copy of the loglines to the orginal `List` within the `ListAppender` which methods are thread-safe but not resulting objects. Then the copy is used by AssertJ.