### PR TITLE
Fix consumer c'an't consume records

### DIFF
--- a/tzatziki-spring-kafka/README.md
+++ b/tzatziki-spring-kafka/README.md
@@ -35,6 +35,7 @@ public class TestApplicationSteps {
         public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
             KafkaSteps.start(); // this will start the embedded kafka
             TestPropertyValues.of(
+                    "spring.kafka.consumer.auto-offset-reset=earliest",
                     "spring.kafka.bootstrap-servers=" + KafkaSteps.bootstrapServers(),
                     "spring.kafka.properties.schema.registry.url=" + KafkaSteps.schemaRegistryUrl() // an optional in-memory schema registry
             ).applyTo(configurableApplicationContext.getEnvironment());


### PR DESCRIPTION
While testing we figured out that the consumer is not able to read some records, we investigated the issue and we have found that the producer is sending them before the consumer starts listening.  the config I add resolves the issue