### PR TITLE
fix(issue #119): Escape empty brackets [] when present in query parameters

### DIFF
--- a/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
+++ b/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
@@ -50,7 +50,7 @@ public class MockFaster {
             .withReasonPhrase("Not Found Again!")
             .withStatusCode(404);
 
-    public static final String INVALID_REGEX_PATTERN = "(\\[\\])";
+    public static final String INVALID_REGEX_PATTERN = "(\\[])";
     private static final String PROTOCOL = "(?:([^:]+)://)?";
     private static final String HOST = "([^/]+)?";
     private static final Pattern URI = Pattern.compile("^" + PROTOCOL + HOST + "((/[^?]+)?(?:\\?(.+))?)?$");

--- a/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
+++ b/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
@@ -50,6 +50,7 @@ public class MockFaster {
             .withReasonPhrase("Not Found Again!")
             .withStatusCode(404);
 
+    public static final String INVALID_REGEX_PATTERN = "(\\[\\])";
     private static final String PROTOCOL = "(?:([^:]+)://)?";
     private static final String HOST = "([^/]+)?";
     private static final Pattern URI = Pattern.compile("^" + PROTOCOL + HOST + "((/[^?]+)?(?:\\?(.+))?)?$");
@@ -392,5 +393,10 @@ public class MockFaster {
         public void respond(ExpectationResponseCallback callback) {
             add_mock(request, callback, comparison);
         }
+    }
+
+    public static String escapeBrackets(String string) {
+        Matcher matcher = Pattern.compile(INVALID_REGEX_PATTERN).matcher(string);
+        return matcher.replaceAll("\\\\[\\\\]");
     }
 }

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -53,6 +53,7 @@ public class HttpSteps {
 
     public static final String STATUS = "([A-Z_]+[A-Z]|\\d+|[A-Z_]+_\\d+)";
 
+
     static {
         DynamicTransformers.register(Method.class, Method::of);
         DynamicTransformers.register(HttpStatusCode.class, HttpSteps::getHttpStatusCode);
@@ -160,7 +161,8 @@ public class HttpSteps {
             interaction.consumptionIndex++;
 
             String queryParamPattern = ofNullable(uri.group(5)).filter(s -> !s.isEmpty()).map(s -> "?" + toQueryString(toParameters(s, false))).orElse("");
-            Pattern urlPattern = Pattern.compile(uri.group(4) + queryParamPattern);
+            String pathString = escapeBrackets(uri.group(4) + queryParamPattern);
+            Pattern urlPattern = Pattern.compile(pathString);
             objects.add("_request", request);
 
             AtomicInteger consumptionSum = new AtomicInteger();
@@ -373,7 +375,7 @@ public class HttpSteps {
         we_receive(guard, comparison, type, content);
     }
 
-    @Then(THAT + GUARD + QUOTED_CONTENT + " has received(?: "+ VERIFICATION+")? " + COUNT_OR_VARIABLE + " " + CALL + "(?: " + VARIABLE + ")?$")
+    @Then(THAT + GUARD + QUOTED_CONTENT + " has received(?: " + VERIFICATION + ")? " + COUNT_OR_VARIABLE + " " + CALL + "(?: " + VARIABLE + ")?$")
     public void mockserver_has_received(Guard guard, String path, String verification, String countAsString, Method method, String variable) {
         guard.in(objects, () -> {
             int expectedNbCalls = objects.getCount(countAsString);
@@ -509,4 +511,6 @@ public class HttpSteps {
             return HttpStatusCode.valueOf(value);
         }
     }
+
+
 }

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -161,8 +161,7 @@ public class HttpSteps {
             interaction.consumptionIndex++;
 
             String queryParamPattern = ofNullable(uri.group(5)).filter(s -> !s.isEmpty()).map(s -> "?" + toQueryString(toParameters(s, false))).orElse("");
-            String pathString = escapeBrackets(uri.group(4) + queryParamPattern);
-            Pattern urlPattern = Pattern.compile(pathString);
+            Pattern urlPattern = Pattern.compile(escapeBrackets(uri.group(4) + queryParamPattern));
             objects.add("_request", request);
 
             AtomicInteger consumptionSum = new AtomicInteger();

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -53,7 +53,6 @@ public class HttpSteps {
 
     public static final String STATUS = "([A-Z_]+[A-Z]|\\d+|[A-Z_]+_\\d+)";
 
-
     static {
         DynamicTransformers.register(Method.class, Method::of);
         DynamicTransformers.register(HttpStatusCode.class, HttpSteps::getHttpStatusCode);

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -511,6 +511,4 @@ public class HttpSteps {
             return HttpStatusCode.valueOf(value);
         }
     }
-
-
 }

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -1205,7 +1205,7 @@ Feature: to interact with an http service and setup mocks
     """
     Then we received a status OK_200
 
-  Scenario: In the Given steps, we have invalid regexes which will be escaped
+  Scenario: Brackets should be handled and escaped properly for HTTP mocks
     Given that getting "http://invalid/regex%5B%5D?re[]toto[]=1" will return a status OK_200
     When we get "http://invalid/regex[]?re[]toto[]=1"
     Then we received a status OK_200

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -1204,3 +1204,9 @@ Feature: to interact with an http service and setup mocks
     <?xml version="1.0" encoding="utf-8"?><ns:user xmlns:ns="http://www.namespace.com">bob</ns:user>
     """
     Then we received a status OK_200
+
+  Scenario: In the Given steps, we have invalid regexes which will be escaped
+    Given that getting "http://invalid/regex%5B%5D?re[]toto[]=1" will return a status OK_200
+    When we get "http://invalid/regex[]?re[]toto[]=1"
+    Then we received a status OK_200
+


### PR DESCRIPTION
- If the url has query parameters and they contain empty brackets, they need to be escaped for the callback function in HttpSteps to complete normally. As done by ``escapeBrackets`` in MockFaster. 
- If the given step, has empty brackets but in the url path this time. Mockserver won't be able to compile the path url to a regex and crash. But for path url you can decode the empty brackets into their UTF-8 encoding, i.e.**%5B** for **[** and **%5D** for **]**, and mockserver will still match the request with the mock. 
- This method of using UTF-8 encoding for the brackets didn't work  for the query parameters, otherwise Mockserver won't be able to match the mock parameter with the real one, so we have to escape them.