### PR TITLE
fix: http mock redefinitions always working

### DIFF
--- a/tzatziki-http/src/test/java/com/decathlon/tzatziki/steps/LimitWebsocketsSteps.java
+++ b/tzatziki-http/src/test/java/com/decathlon/tzatziki/steps/LimitWebsocketsSteps.java
@@ -1,0 +1,12 @@
+package com.decathlon.tzatziki.steps;
+
+import io.cucumber.java.Before;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class LimitWebsocketsSteps {
+    @Before(order = -2)
+    public void before() {
+        System.setProperty("mockserver.maxWebSocketExpectations", "200");
+    }
+}

--- a/tzatziki-http/src/test/java/com/decathlon/tzatziki/steps/LocalSteps.java
+++ b/tzatziki-http/src/test/java/com/decathlon/tzatziki/steps/LocalSteps.java
@@ -1,9 +1,17 @@
 package com.decathlon.tzatziki.steps;
 
+import com.decathlon.tzatziki.utils.Comparison;
+import com.decathlon.tzatziki.utils.Guard;
 import com.decathlon.tzatziki.utils.Interaction;
 import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import lombok.RequiredArgsConstructor;
 
+import java.util.stream.IntStream;
+
+@RequiredArgsConstructor
 public class LocalSteps {
+    private final HttpSteps httpSteps;
 
     static {
         Interaction.printResponses = true;
@@ -11,4 +19,17 @@ public class LocalSteps {
 
     @Before
     public void before() {}
+
+    @Given("^we add (\\d+)-(\\d+) mocks for id endpoint$")
+    public void mockIdEndpointAsSeveralMocks(int startId, int endId) {
+        IntStream.range(startId, endId + 1).forEach(idx -> httpSteps.url_is_mocked_as(Guard.always(), "http://backend/" + idx, Comparison.CONTAINS, """
+                request:
+                    method: GET
+                response:
+                    headers:
+                        Content-Type: application/json
+                    body:
+                        payload: Hello %d
+                """.formatted(idx)));
+    }
 }

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -1204,3 +1204,15 @@ Feature: to interact with an http service and setup mocks
     <?xml version="1.0" encoding="utf-8"?><ns:user xmlns:ns="http://www.namespace.com">bob</ns:user>
     """
     Then we received a status OK_200
+
+  Scenario Template: Exceed max amount of expectation
+    Given we add 1-1 mocks for id endpoint
+    Given we add <mocksRange> mocks for id endpoint
+    Then getting on "http://backend/1" returns:
+    """
+    Hello 1
+    """
+    Examples:
+      | mocksRange |
+      | 2-150      |
+      | 151-250    |


### PR DESCRIPTION
Circular map for registry is now properly handled by removing and adding back redefinitions of existing mocks to keep clientId in registry