### PR TITLE
Add compatibility for Spring Boot 3.X.X (Jakarta / Kafka upgrade)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-
       - name: Build
         run: mvn -B verify
 

--- a/mockfaster/pom.xml
+++ b/mockfaster/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>3.3.0</version>
+            <version>5.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2021.0.0</version>
+                <version>2022.0.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -79,7 +79,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.6.2</version>
+                <version>3.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tzatziki-spring-jpa/pom.xml
+++ b/tzatziki-spring-jpa/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-hibernate5-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate5</artifactId>
         </dependency>
         <dependency>
@@ -54,7 +58,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>6.4.4</version>
+            <version>9.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/utils/PersistenceUtil.java
+++ b/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/utils/PersistenceUtil.java
@@ -1,0 +1,45 @@
+package com.decathlon.tzatziki.utils;
+
+import com.fasterxml.jackson.databind.Module;
+import edu.emory.mathcs.backport.java.util.Collections;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.decathlon.tzatziki.utils.Unchecked.unchecked;
+
+@SuppressWarnings("unchecked")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PersistenceUtil {
+    private static final Map<String, Class<?>> persistenceClassByName = Collections.synchronizedMap(new HashMap<>());
+
+    public static Module getMapperModule() {
+        Class<?> tableClass = getPersistenceClass("Table");
+        Class<Module> mapperModuleClass;
+
+        if (tableClass.getPackageName().equals("javax.persistence"))
+            mapperModuleClass = unchecked(() -> (Class<Module>) Class.forName("com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module"));
+        else
+            mapperModuleClass = unchecked(() -> (Class<Module>) Class.forName("com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule"));
+
+        return unchecked(() -> mapperModuleClass.getConstructor().newInstance());
+    }
+
+    public static <T> Class<T> getPersistenceClass(String className) {
+        return (Class<T>) persistenceClassByName.computeIfAbsent(
+                className,
+                clazz -> {
+                    Class<Object> foundClass;
+                    try {
+                        foundClass = (Class<Object>) Class.forName("javax.persistence." + className);
+                    } catch (ClassNotFoundException e) {
+                        foundClass = unchecked(() -> (Class<Object>) Class.forName("jakarta.persistence." + className));
+                    }
+                    return foundClass;
+                }
+        );
+    }
+
+}

--- a/tzatziki-spring-jpa/src/test/java/com/another_org/CorruptedEvilness.java
+++ b/tzatziki-spring-jpa/src/test/java/com/another_org/CorruptedEvilness.java
@@ -1,9 +1,13 @@
 package com.another_org;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @NoArgsConstructor
 @Getter

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/TestApplication.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/TestApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.decathlon.tzatziki")
 @EnableJpaRepositories(basePackages = {"com.another_org", "com.decathlon.tzatziki.app"})
 @EntityScan(basePackages = {"com.another_org", "com.decathlon.tzatziki.app"})
 public class TestApplication {

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/entity_listeners/SuperUserEntityListener.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/entity_listeners/SuperUserEntityListener.java
@@ -2,7 +2,7 @@ package com.decathlon.tzatziki.app.entity_listeners;
 
 import com.decathlon.tzatziki.app.model.SuperUser;
 
-import javax.persistence.PrePersist;
+import jakarta.persistence.PrePersist;
 
 public class SuperUserEntityListener {
     @PrePersist

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Evilness.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Evilness.java
@@ -1,10 +1,13 @@
 package com.decathlon.tzatziki.app.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import java.time.Instant;
 
 @NoArgsConstructor
 @Getter

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Group.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Group.java
@@ -1,10 +1,15 @@
 package com.decathlon.tzatziki.app.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import java.util.List;
 
 @NoArgsConstructor
 @Getter

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/SuperUser.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/SuperUser.java
@@ -1,14 +1,13 @@
 package com.decathlon.tzatziki.app.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Table;
 import com.decathlon.tzatziki.app.entity_listeners.SuperUserEntityListener;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.Table;
 
 @Getter
 @Entity

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/User.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/User.java
@@ -1,12 +1,19 @@
 package com.decathlon.tzatziki.app.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
-import java.time.Instant;
-
-import static javax.persistence.InheritanceType.JOINED;
+import static jakarta.persistence.InheritanceType.JOINED;
 
 @Getter
 @Entity

--- a/tzatziki-spring-kafka/src/main/java/com/decathlon/tzatziki/steps/KafkaSteps.java
+++ b/tzatziki-spring-kafka/src/main/java/com/decathlon/tzatziki/steps/KafkaSteps.java
@@ -2,21 +2,39 @@ package com.decathlon.tzatziki.steps;
 
 import com.decathlon.tzatziki.kafka.KafkaInterceptor;
 import com.decathlon.tzatziki.kafka.SchemaRegistry;
-import com.decathlon.tzatziki.utils.Comparison;
-import com.decathlon.tzatziki.utils.Guard;
-import com.decathlon.tzatziki.utils.Mapper;
-import com.decathlon.tzatziki.utils.MockFaster;
+import com.decathlon.tzatziki.utils.*;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.apache.kafka.clients.admin.*;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ConsumerGroupDescription;
+import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -36,21 +54,18 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
-
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Semaphore;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import org.springframework.util.concurrent.ListenableFuture;
 
 import static com.decathlon.tzatziki.kafka.KafkaInterceptor.offsets;
 import static com.decathlon.tzatziki.utils.Asserts.awaitUntil;
 import static com.decathlon.tzatziki.utils.Asserts.awaitUntilAsserted;
 import static com.decathlon.tzatziki.utils.Comparison.COMPARING_WITH;
 import static com.decathlon.tzatziki.utils.Guard.GUARD;
-import static com.decathlon.tzatziki.utils.Patterns.*;
+import static com.decathlon.tzatziki.utils.Patterns.A;
+import static com.decathlon.tzatziki.utils.Patterns.A_USER;
+import static com.decathlon.tzatziki.utils.Patterns.THAT;
+import static com.decathlon.tzatziki.utils.Patterns.VARIABLE;
+import static com.decathlon.tzatziki.utils.Patterns.VARIABLE_PATTERN;
 import static com.decathlon.tzatziki.utils.Unchecked.unchecked;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ROOT;
@@ -359,7 +374,8 @@ public class KafkaSteps {
                 .stream()
                 .map(avroRecord -> {
                     ProducerRecord<String, GenericRecord> producerRecord = mapToAvroRecord(schema, topic, avroRecord);
-                    return avroKafkaTemplate.send(producerRecord).completable().join();
+                    
+                    return blockingSend(avroKafkaTemplate, producerRecord);
                 }).collect(Collectors.toList());
         avroKafkaTemplate.flush();
         return messages;
@@ -413,7 +429,7 @@ public class KafkaSteps {
     private List<SendResult<String, ?>> publishJson(String topic, List<Map<String, Object>> records) {
         List<SendResult<String, ?>> messages = records
                 .stream()
-                .map(jsonRecord -> jsonKafkaTemplate.send(mapToJsonRecord(topic, jsonRecord)).completable().join()).collect(Collectors.toList());
+                .map(jsonRecord -> blockingSend(jsonKafkaTemplate, mapToJsonRecord(topic, jsonRecord))).collect(Collectors.toList());
         jsonKafkaTemplate.flush();
         return messages;
     }
@@ -497,5 +513,14 @@ public class KafkaSteps {
         }
         assertThat(schema).isInstanceOf(Schema.class);
         return (Schema) schema;
+    }
+    
+    private <K, V> SendResult<K, V> blockingSend(KafkaTemplate<K, V> kafkaTemplate, ProducerRecord<K, V> producerRecord){
+        Object sendReturn = Methods.invoke(kafkaTemplate, "send", producerRecord);
+        CompletableFuture<SendResult<K, V>> future = sendReturn instanceof ListenableFuture listenableFuture 
+                ? listenableFuture.completable() 
+                : (CompletableFuture<SendResult<K, V>>) sendReturn;
+        
+        return future.join();
     }
 }

--- a/tzatziki-spring-kafka/src/test/java/com/decathlon/tzatziki/kafka/KafkaUsersListener.java
+++ b/tzatziki-spring-kafka/src/test/java/com/decathlon/tzatziki/kafka/KafkaUsersListener.java
@@ -1,5 +1,6 @@
 package com.decathlon.tzatziki.kafka;
 
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -10,9 +11,10 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
-import static org.springframework.kafka.support.KafkaHeaders.*;
+import static org.springframework.kafka.support.KafkaHeaders.OFFSET;
+import static org.springframework.kafka.support.KafkaHeaders.RECEIVED_KEY;
+import static org.springframework.kafka.support.KafkaHeaders.RECEIVED_PARTITION;
+import static org.springframework.kafka.support.KafkaHeaders.RECEIVED_TOPIC;
 
 @Service
 @Slf4j
@@ -39,7 +41,7 @@ public class KafkaUsersListener extends AbstractConsumerSeekAware implements See
 
     @KafkaListener(topics = "json-users-with-key", groupId = "users-group-id", containerFactory = "jsonBatchFactory")
     public void receivedUserWithKeyAsJson(@Payload List<String> messages,
-                                          @Header(RECEIVED_MESSAGE_KEY) List<String> messageKey) {
+                                          @Header(RECEIVED_KEY) List<String> messageKey) {
         for (int idx = 0; idx < messages.size(); idx++) {
             try {
                 countService.countMessage("json-users-with-key");
@@ -53,7 +55,7 @@ public class KafkaUsersListener extends AbstractConsumerSeekAware implements See
     @KafkaListener(topics = "users-with-headers", groupId = "users-with-headers-group-id", containerFactory = "batchFactory")
     public void receivedUserWithHeader(
             @Payload List<GenericRecord> messagePayloads,
-            @Header(RECEIVED_PARTITION_ID) List<Long> partitions,
+            @Header(RECEIVED_PARTITION) List<Long> partitions,
             @Header(OFFSET) List<Long> offsets,
             @Header(RECEIVED_TOPIC) List<String> topics) {
         log.error("{} messages received", messagePayloads.size());
@@ -71,8 +73,8 @@ public class KafkaUsersListener extends AbstractConsumerSeekAware implements See
     @KafkaListener(topics = "users-with-key", groupId = "users-with-key-group-id", containerFactory = "batchFactory")
     public void receivedUserWithKey(
             @Payload List<GenericRecord> messagePayloads,
-            @Header(RECEIVED_PARTITION_ID) List<Long> partitions,
-            @Header(RECEIVED_MESSAGE_KEY) List<String> messageKey,
+            @Header(RECEIVED_PARTITION) List<Long> partitions,
+            @Header(RECEIVED_KEY) List<String> messageKey,
             @Header(OFFSET) List<Long> offsets,
             @Header(RECEIVED_TOPIC) List<String> topics) {
         log.error("{} messages received", messagePayloads.size());

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
@@ -8,23 +8,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
-import org.springframework.context.ApplicationContext;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationContext;
 
 import static com.decathlon.tzatziki.utils.Comparison.COMPARING_WITH;
 import static com.decathlon.tzatziki.utils.Guard.GUARD;
 import static com.decathlon.tzatziki.utils.Guard.always;
-import static com.decathlon.tzatziki.utils.Patterns.*;
+import static com.decathlon.tzatziki.utils.Patterns.A_USER;
+import static com.decathlon.tzatziki.utils.Patterns.THAT;
+import static com.decathlon.tzatziki.utils.Patterns.VARIABLE;
 import static org.junit.Assert.assertNotNull;
 
 public class SpringSteps {


### PR DESCRIPTION
Impacted Modules : 
- Parent : Upgrade the spring boot and the spring cloud version
- Spring Http : move the @LocalServerPort package
- Mockfaster : Upgrade the rest-assured module version
- Spring JPA : move the javax.persistence.* packages to jakarta.persistence.*
- Spring JPA : Move the jackson-datatype-hibernate5 to jackson-datatype-hibernate5-jakarta (the first one still uses javax.persistence.*)
- Spring Kafka : replace RecoveringBatchErrorHandler and SeekToCurrentErrorHandler classes with DefaultErrorHandler as they are now deprecated