### PR TITLE
fix: can now assert count number with path containing regex which doe…

### DIFF
--- a/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
+++ b/mockfaster/src/main/java/com/decathlon/tzatziki/utils/MockFaster.java
@@ -115,11 +115,13 @@ public class MockFaster {
                     });
         }
 
+        String pattern;
         if (httpRequest.getPath() instanceof NottableSchemaString uriSchema) {
-            PATH_PATTERNS.add(Pattern.compile(((ObjectNode) getValue(uriSchema, "schemaJsonNode")).get("pattern").textValue()));
+            pattern = ((ObjectNode) getValue(uriSchema, "schemaJsonNode")).get("pattern").textValue();
         } else {
-            PATH_PATTERNS.add(Pattern.compile(httpRequest.getPath().getValue()));
+            pattern = httpRequest.getPath().getValue();
         }
+        PATH_PATTERNS.add(Pattern.compile(pattern.replaceAll("\\([^()]*\\)","(.*)")));
     }
 
     private static void modifyJsonStrictnessMatcher(List<HttpRequestMatcher> httpRequestMatchers, Comparison comparison) {

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -1334,3 +1334,21 @@ Feature: to interact with an http service and setup mocks
       | {"headers":{"my-header":"a bad value"}}                                                         |
       | {"headers":{"my-header":"a good value"},"body":{"payload":{"my-body":{"field":"a bad value"}}}} |
       | {"body":{"payload":{"my-body":{"field":"a bad value"}}}}                                        |
+
+  Scenario: Requests count assertion should also work for digit
+    And that getting on "http://backend/pipe/([a-z]*)/([0-9]*)/(\d+)" will return a status OK_200 and:
+    """
+    $1|$2|$3
+    """
+    When we get on "http://backend/pipe/a/1/2"
+    Then we received a status OK_200 and:
+    """
+    a|1|2
+    """
+    When we get on "http://backend/pipe/c/3/4"
+    Then we received a status OK_200 and:
+    """
+    c|3|4
+    """
+    And "http://backend/pipe/[a-b]*/1/\d+" has received 1 GET
+    And "http://backend/pipe/.*/\d*/\d+" has received 2 GETs


### PR DESCRIPTION
…sn't match the initial mocks