### PR TITLE
Add clear thread pool context function

### DIFF
--- a/tzatziki-spring/README.md
+++ b/tzatziki-spring/README.md
@@ -145,7 +145,7 @@ static {
 
 ## Spring task executor context clean
 
-By default, the thread pool task executor queue is not clean between tests. 
+By default, the thread pool task executor queue is not cleaned between tests. 
 
 If you want to enable the clean between tests:
 

--- a/tzatziki-spring/README.md
+++ b/tzatziki-spring/README.md
@@ -145,7 +145,7 @@ static {
 
 ## Spring task executor context clean
 
-By default, the thread pool task executor queue is not be clean between tests. 
+By default, the thread pool task executor queue is not clean between tests. 
 
 If you want to enable the clean between tests:
 

--- a/tzatziki-spring/README.md
+++ b/tzatziki-spring/README.md
@@ -145,7 +145,7 @@ static {
 
 ## Spring task executor context clean
 
-By default, the thread pool task executor queue will not be clean between tests. 
+By default, the thread pool task executor queue is not be clean between tests. 
 
 If you want to enable the clean between tests:
 

--- a/tzatziki-spring/README.md
+++ b/tzatziki-spring/README.md
@@ -143,6 +143,18 @@ static {
 }
 ```
 
+## Spring task executor context clean
+
+By default, the thread pool task executor queue will not be clean between tests. 
+
+If you want to enable the clean between tests:
+
+```java
+static {
+    SpringSteps.clearThreadPoolExecutor = true;
+}
+```
+
 ## Steps local to this library
 
 This library doesn't come with a lot of steps, but it will start your Spring automatically 

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
@@ -9,11 +9,6 @@ import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Predicate;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -21,6 +16,12 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import static com.decathlon.tzatziki.utils.Comparison.COMPARING_WITH;
 import static com.decathlon.tzatziki.utils.Guard.GUARD;
@@ -40,11 +41,10 @@ public class SpringSteps {
     private List<CacheManager> cacheManagers;
     @Autowired(required = false)
     private ObjectMapper objectMapper;
-    @LocalServerPort
-    private int localServerPort;
-
     @Autowired(required = false)
     ThreadPoolTaskExecutor taskExecutor;
+    @LocalServerPort
+    private int localServerPort;
 
     public static boolean copyNamingStrategyFromSpringMapper = true;
     public static boolean clearThreadPoolExecutor = false;

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
@@ -42,7 +42,7 @@ public class SpringSteps {
     @Autowired(required = false)
     private ObjectMapper objectMapper;
     @Autowired(required = false)
-    ThreadPoolTaskExecutor taskExecutor;
+    private ThreadPoolTaskExecutor taskExecutor;
     @LocalServerPort
     private int localServerPort;
 

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
@@ -3,6 +3,7 @@ package com.decathlon.tzatziki.steps;
 import com.decathlon.tzatziki.app.TestApplication;
 import com.decathlon.tzatziki.spring.HttpInterceptor;
 import com.decathlon.tzatziki.utils.Asserts;
+import com.decathlon.tzatziki.utils.Guard;
 import com.decathlon.tzatziki.utils.Patterns;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
@@ -20,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static com.decathlon.tzatziki.utils.Guard.GUARD;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @CucumberContextConfiguration
@@ -30,7 +32,7 @@ public class TestApplicationSteps {
     private static Future<?> completableFutureToTest;
 
     @Autowired
-    ThreadPoolTaskExecutor taskExecutor;
+    private ThreadPoolTaskExecutor taskExecutor;
 
 
     static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
@@ -51,9 +53,8 @@ public class TestApplicationSteps {
 
 
     @Given(Patterns.THAT + "clean thread pool executor is (enabled|disabled)")
-    public void clead_thread_pool_executor(String enabled) {
+    public void thread_pool_executor_clean(String enabled) {
         SpringSteps.clearThreadPoolExecutor = "enabled".equals(enabled);
-
     }
 
     @Given(Patterns.THAT + "we start an infinite task")

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
@@ -58,16 +58,16 @@ public class TestApplicationSteps {
     }
 
 
-    @Given(Patterns.THAT + "clean thread pool executor is (enabled|disabled)")
-    public void thread_pool_executor_clean(String enabled) {
-        SpringSteps.clearThreadPoolExecutor = "enabled".equals(enabled);
+    @Given(Patterns.THAT + "the thread pool executor is (not )?cleaned between test runs")
+    public void thread_pool_executor_clean(String negation) {
+        SpringSteps.clearThreadPoolExecutor = !"not ".equals(negation);
     }
 
     @Given(Patterns.THAT + "we start an infinite task")
     public void start_infinite_task() {
         completableFutureToTest = taskExecutor.submit(() -> {
             try {
-                new CountDownLatch(1).await(10, TimeUnit.SECONDS);
+                new CountDownLatch(1).await(1000, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
@@ -2,16 +2,21 @@ package com.decathlon.tzatziki.steps;
 
 import com.decathlon.tzatziki.app.TestApplication;
 import com.decathlon.tzatziki.spring.HttpInterceptor;
-import com.decathlon.tzatziki.utils.JacksonMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.decathlon.tzatziki.utils.Asserts;
+import com.decathlon.tzatziki.utils.Patterns;
 import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.spring.CucumberContextConfiguration;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.util.concurrent.Future;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
@@ -20,6 +25,12 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @ContextConfiguration(initializers = TestApplicationSteps.Initializer.class)
 @Slf4j
 public class TestApplicationSteps {
+    private static Future<?> completableFutureToTest;
+
+    @Autowired
+    ThreadPoolTaskExecutor taskExecutor;
+
+
     static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
         public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
@@ -35,4 +46,28 @@ public class TestApplicationSteps {
     public void if_we_disable_the_http_interceptor() {
         HttpInterceptor.disable();
     }
+
+
+    @Given(Patterns.THAT + "clean thread pool executor is (enabled|disabled)")
+    public void clead_thread_pool_executor(String enabled) {
+        SpringSteps.clearThreadPoolExecutor = "enabled".equals(enabled);
+
+    }
+
+    @Given(Patterns.THAT + "we start an infinite task")
+    public void start_infinite_task() {
+        completableFutureToTest = taskExecutor.submit(() -> {
+            try {
+                Thread.sleep(100000000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Then(Patterns.THAT + "infinite task (has been|has not been) shutdown")
+    public void infinite_task_has_been_shutdown(String negation) {
+        Asserts.equals(completableFutureToTest.isDone(), !"has not been".equals(negation));
+    }
+
 }

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
@@ -16,7 +16,9 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
@@ -58,7 +60,7 @@ public class TestApplicationSteps {
     public void start_infinite_task() {
         completableFutureToTest = taskExecutor.submit(() -> {
             try {
-                Thread.sleep(100000000);
+                new CountDownLatch(1).await(10, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
+++ b/tzatziki-spring/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
@@ -2,7 +2,6 @@ package com.decathlon.tzatziki.steps;
 
 import com.decathlon.tzatziki.app.TestApplication;
 import com.decathlon.tzatziki.spring.HttpInterceptor;
-import com.decathlon.tzatziki.utils.Asserts;
 import com.decathlon.tzatziki.utils.Guard;
 import com.decathlon.tzatziki.utils.Patterns;
 import io.cucumber.java.Before;
@@ -10,6 +9,7 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.spring.CucumberContextConfiguration;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContextInitializer;
@@ -31,8 +31,14 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 public class TestApplicationSteps {
     private static Future<?> completableFutureToTest;
 
+    private final ObjectSteps objectSteps;
+
     @Autowired
     private ThreadPoolTaskExecutor taskExecutor;
+
+    public TestApplicationSteps(ObjectSteps objectSteps) {
+        this.objectSteps = objectSteps;
+    }
 
 
     static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
@@ -68,9 +74,9 @@ public class TestApplicationSteps {
         });
     }
 
-    @Then(Patterns.THAT + "infinite task (has been|has not been) shutdown")
-    public void infinite_task_has_been_shutdown(String negation) {
-        Asserts.equals(completableFutureToTest.isDone(), !"has not been".equals(negation));
+    @Then(Patterns.THAT + GUARD + "infinite task has been shutdown")
+    public void infinite_task_has_been_shutdown(Guard guard) {
+        guard.in(objectSteps, () -> Assertions.assertTrue(completableFutureToTest.isDone()));
     }
 
 }

--- a/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
+++ b/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
@@ -76,14 +76,14 @@ Feature: to interact with a spring boot service
     Then helloResponse.body is equal to "Hello world!"
 
   Scenario: we start an infinite task if clear thread pool executor is enabled
-    Given that clean thread pool executor is enabled
+    Given the thread pool executor is cleaned between test runs
     And that we start an infinite task
 
   Scenario: then the infinite task has been cancelled
     Then infinite task has been shutdown
 
   Scenario: we start an infinite task if clear thread pool executor is disabled
-    Given that clean thread pool executor is disabled
+    Given the thread pool executor is not cleaned between test runs
     And that we start an infinite task
 
   Scenario: then the infinite task has not been cancelled

--- a/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
+++ b/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
@@ -87,4 +87,4 @@ Feature: to interact with a spring boot service
     And that we start an infinite task
 
   Scenario: then the infinite task has not been cancelled
-    Then infinite task has not been shutdown
+    Then it is not true that infinite task has been shutdown

--- a/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
+++ b/tzatziki-spring/src/test/resources/com/decathlon/tzatziki/steps/spring.feature
@@ -74,3 +74,17 @@ Feature: to interact with a spring boot service
     Given that helloController is a HelloController "{{{[_application.getBean({{{HelloController}}})]}}}"
     And that helloResponse is "{{{[helloController.hello()]}}}"
     Then helloResponse.body is equal to "Hello world!"
+
+  Scenario: we start an infinite task if clear thread pool executor is enabled
+    Given that clean thread pool executor is enabled
+    And that we start an infinite task
+
+  Scenario: then the infinite task has been cancelled
+    Then infinite task has been shutdown
+
+  Scenario: we start an infinite task if clear thread pool executor is disabled
+    Given that clean thread pool executor is disabled
+    And that we start an infinite task
+
+  Scenario: then the infinite task has not been cancelled
+    Then infinite task has not been shutdown


### PR DESCRIPTION
By default, the thread pool task executor queue is not clean between tests. 

If you want to enable the clean between tests:

```java
static {
    SpringSteps.clearThreadPoolExecutor = true;
}
```
This clean can be very useful because we have seen some unpredictable behaviors during tests in our projects. It is due to background task from old test that is interfering with other test context.