### PR TITLE
fix: none spring web app crashing because no "@LocalServerPort"

### DIFF
--- a/tzatziki-spring-jpa/pom.xml
+++ b/tzatziki-spring-jpa/pom.xml
@@ -56,6 +56,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>9.12.0</version>

--- a/tzatziki-spring-kafka/pom.xml
+++ b/tzatziki-spring-kafka/pom.xml
@@ -104,6 +104,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tzatziki-spring-kafka/pom.xml
+++ b/tzatziki-spring-kafka/pom.xml
@@ -110,6 +110,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tzatziki-spring/pom.xml
+++ b/tzatziki-spring/pom.xml
@@ -73,10 +73,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
@@ -8,6 +8,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRequest;
@@ -26,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.function.Function;
 
+@ConditionalOnWebApplication
 @Aspect
 @Component
 @Slf4j

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/steps/SpringSteps.java
@@ -9,6 +9,7 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -35,8 +36,8 @@ public class SpringSteps {
     private List<CacheManager> cacheManagers;
     @Autowired(required = false)
     private ObjectMapper objectMapper;
-    @LocalServerPort
-    private int localServerPort;
+    @Value("${local.server.port:}")
+    private Integer localServerPort;
 
     public static boolean copyNamingStrategyFromSpringMapper = true;
 
@@ -51,11 +52,13 @@ public class SpringSteps {
 
     @Before(order = -1)
     public void before() {
-        http.setRelativeUrlRewriter(path -> "http://localhost:%s%s".formatted(localServerPort, path));
+        if(Objects.nonNull(localServerPort)){
+            http.setRelativeUrlRewriter(path -> "http://localhost:%s%s".formatted(localServerPort, path));
+        }
         if (applicationContext != null) {
             we_clear_all_the_caches(always());
 
-            if (copyNamingStrategyFromSpringMapper) {
+            if (copyNamingStrategyFromSpringMapper && Objects.nonNull(objectMapper)) {
                 JacksonMapper.with(mapper -> mapper.setPropertyNamingStrategy(objectMapper.getPropertyNamingStrategy()));
                 copyNamingStrategyFromSpringMapper = false;
             }


### PR DESCRIPTION
- For non-web applications, spring web dependencies have been passed to the **provided** scope so as not to load them during the test phase.
- HttpInterceptor passed to **OnCondtionalWebApplication** because dependent on spring web, so non-web projects should not load it.
- For non-web projects, the **LocalServerPort** uses the @Value to have a default value.