### PR TITLE
Restrict HttpInterceptor AOP to none final class

### DIFF
--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
@@ -43,7 +43,7 @@ public class HttpInterceptor {
         enabled = false;
     }
 
-    @Around("@annotation(org.springframework.context.annotation.Bean)")
+    @Around("@annotation(org.springframework.context.annotation.Bean) && !within(is(FinalType))")
     public Object beanCreation(ProceedingJoinPoint joinPoint) throws Throwable {
         Object bean = joinPoint.proceed();
         if (enabled) {


### PR DESCRIPTION
Starting migration of our application to Spring boot 3, I've been struggling with some AOP issue : 
Could not generate CGLIB subclass of class org.springframework.security.config.annotation.method.configuration.PrePostMethodSecurityConfiguration

After some investigation, I found out it is because HttpInterceptor try to proxy PrePostMethodSecurityConfiguration which is a final class. 
This behavior can easily be reproduced with Spring security and the annotation @EnableMethodSecurity.

The quick fix I implemented is to adapt the Pointcut expression to not match final classes. 

It seems to fix the issue, I did not add test because it seem to be a really specific problem. 