### PR TITLE
Split HttpInterceptor to avoid spring web / webflux forced dependency

### DIFF
--- a/tzatziki-spring-jpa/pom.xml
+++ b/tzatziki-spring-jpa/pom.xml
@@ -56,11 +56,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>9.12.0</version>

--- a/tzatziki-spring-kafka/pom.xml
+++ b/tzatziki-spring-kafka/pom.xml
@@ -110,11 +110,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/DefaultWebClientDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/DefaultWebClientDefinition.java
@@ -1,0 +1,45 @@
+package com.decathlon.tzatziki.spring;
+
+import com.decathlon.tzatziki.utils.Fields;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.function.Function;
+
+
+@ConditionalOnClass(WebClient.class)
+@Component
+public class DefaultWebClientDefinition implements HttpInterceptorDefinition<WebClient> {
+    @Override
+    public WebClient rewrite(WebClient webClient) {
+        if (!webClient.getClass().getName().equals("org.springframework.web.reactive.function.client.DefaultWebClient")) {
+            return webClient;
+        }
+        ExchangeFunction exchangeFunction = Fields.getValue(webClient, "exchangeFunction");
+        if (Fields.hasField(exchangeFunction, "connector")) {
+            // we assume that this webClient was created by a builder that we already intercepted
+            ClientHttpConnector clientHttpConnector = Fields.getValue(exchangeFunction, "connector");
+            Fields.setValue(exchangeFunction, "connector", new ClientHttpConnector() {
+                @Override
+                @SneakyThrows
+                public @NotNull Mono<ClientHttpResponse> connect(
+                        @NotNull HttpMethod method,
+                        @NotNull URI uri,
+                        @NotNull Function<? super ClientHttpRequest, Mono<Void>> requestCallback) {
+                    return clientHttpConnector.connect(method, HttpInterceptor.remap(uri), requestCallback);
+                }
+            });
+        }
+        return webClient;
+    }
+}

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
@@ -34,7 +34,7 @@ public class HttpInterceptor {
     @Autowired(required = false)
     private List<HttpInterceptorDefinition> httpInterceptorDefinitions;
 
-    @Around("@annotation(org.springframework.context.annotation.Bean)")
+    @Around("@annotation(org.springframework.context.annotation.Bean) && !within(is(FinalType))")
     public Object beanCreation(ProceedingJoinPoint joinPoint) throws Throwable {
         Object bean = joinPoint.proceed();
         if (enabled && bean != null && httpInterceptorDefinitions != null) {

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptor.java
@@ -1,31 +1,19 @@
 package com.decathlon.tzatziki.spring;
 
-import com.decathlon.tzatziki.utils.Fields;
 import com.decathlon.tzatziki.utils.MockFaster;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpRequest;
-import org.springframework.http.client.*;
-import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.ClientRequest;
-import org.springframework.web.reactive.function.client.ExchangeFunction;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
-import java.io.IOException;
-import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.function.Function;
+import java.util.List;
 
 @ConditionalOnWebApplication
 @Aspect
@@ -43,76 +31,31 @@ public class HttpInterceptor {
         enabled = false;
     }
 
+    @Autowired(required = false)
+    private List<HttpInterceptorDefinition> httpInterceptorDefinitions;
+
     @Around("@annotation(org.springframework.context.annotation.Bean)")
     public Object beanCreation(ProceedingJoinPoint joinPoint) throws Throwable {
         Object bean = joinPoint.proceed();
-        if (enabled) {
-            if (bean instanceof RestTemplate restTemplate) {
-                ClientHttpRequestFactory requestFactory = Fields.getValue(restTemplate, "requestFactory");
-                Fields.setValue(restTemplate, "requestFactory", new ClientHttpRequestFactory() {
-                    @SneakyThrows
-                    @Override
-                    public @NotNull
-                    ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) throws IOException {
-                        return requestFactory.createRequest(remap(uri), httpMethod);
-                    }
-                });
-                return restTemplate;
-            } else if (bean instanceof RestTemplateBuilder restTemplateBuilder) {
-                return restTemplateBuilder.additionalInterceptors(new ClientHttpRequestInterceptor() {
-                    @Override
-                    public @NotNull ClientHttpResponse intercept(
-                            @NotNull HttpRequest request,
-                            byte @NotNull [] body,
-                            @NotNull ClientHttpRequestExecution execution) throws IOException {
-                        HttpRequest proxiedHttpRequest = (HttpRequest) Proxy.newProxyInstance(
-                                request.getClass().getClassLoader(),
-                                new Class[]{HttpRequest.class},
-                                (proxy, method, args) -> switch (method.getName()) {
-                                    case "getURI" -> remap(request.getURI());
-                                    default -> method.invoke(request, args);
-                                });
-                        return execution.execute(proxiedHttpRequest, body);
-                    }
-                });
-            } else if (bean instanceof WebClient webClient && bean.getClass().getName().equals("org.springframework.web.reactive.function.client.DefaultWebClient")) {
-                ExchangeFunction exchangeFunction = Fields.getValue(bean, "exchangeFunction");
-                if (Fields.hasField(exchangeFunction, "connector")) {
-                    // we assume that this webClient was created by a builder that we already intercepted
-                    ClientHttpConnector clientHttpConnector = Fields.getValue(exchangeFunction, "connector");
-                    Fields.setValue(exchangeFunction, "connector", new ClientHttpConnector() {
-                        @Override
-                        @SneakyThrows
-                        public @NotNull Mono<org.springframework.http.client.reactive.ClientHttpResponse> connect(
-                                @NotNull HttpMethod method,
-                                @NotNull URI uri,
-                                @NotNull Function<? super org.springframework.http.client.reactive.ClientHttpRequest, Mono<Void>> requestCallback) {
-                            return clientHttpConnector.connect(method, remap(uri), requestCallback);
-                        }
-                    });
-                }
-                return webClient;
-            } else if (bean instanceof WebClient.Builder webClientBuilder) {
-                return webClientBuilder.filter((request, next) -> {
-                    ClientRequest proxiedClientRequest = (ClientRequest) Proxy.newProxyInstance(
-                            ClientRequest.class.getClassLoader(),
-                            new Class[]{ClientRequest.class},
-                            (proxy, method, args) -> switch (method.getName()) {
-                                case "url" -> remap(request.url());
-                                default -> method.invoke(request, args);
-                            });
-                    return next.exchange(proxiedClientRequest);
-                });
-            }
+        if (enabled && bean != null && httpInterceptorDefinitions != null) {
+            return httpInterceptorDefinitions.stream()
+                    .filter(httpInterceptorDefinition -> isBeanMatchingDefinition(bean, httpInterceptorDefinition)).findFirst()
+                    .map(httpInterceptorDefinition -> httpInterceptorDefinition.rewrite(bean)).orElse(bean);
+
         }
         return bean;
     }
 
     @NotNull
-    private URI remap(URI uri) throws URISyntaxException {
+    static URI remap(URI uri) throws URISyntaxException {
         if (enabled) {
             return new URI(MockFaster.target(uri.toString()));
         }
         return uri;
+    }
+
+    private boolean isBeanMatchingDefinition(Object bean, HttpInterceptorDefinition<?> definition) {
+        Class<?> resolvedType = ResolvableType.forClass(definition.getClass()).getInterfaces()[0].getGeneric(0).resolve();
+        return resolvedType != null && resolvedType.isInstance(bean);
     }
 }

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptorDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptorDefinition.java
@@ -1,0 +1,5 @@
+package com.decathlon.tzatziki.spring;
+
+public interface HttpInterceptorDefinition<T> {
+    T rewrite(T webClient);
+}

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptorDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/HttpInterceptorDefinition.java
@@ -1,5 +1,5 @@
 package com.decathlon.tzatziki.spring;
 
 public interface HttpInterceptorDefinition<T> {
-    T rewrite(T webClient);
+    T rewrite(T httpClient);
 }

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateBuilderDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateBuilderDefinition.java
@@ -17,8 +17,8 @@ import java.lang.reflect.Proxy;
 @Component
 public class RestTemplateBuilderDefinition implements HttpInterceptorDefinition<RestTemplateBuilder> {
     @Override
-    public RestTemplateBuilder rewrite(RestTemplateBuilder webClient) {
-        return webClient.additionalInterceptors(new ClientHttpRequestInterceptor() {
+    public RestTemplateBuilder rewrite(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder.additionalInterceptors(new ClientHttpRequestInterceptor() {
             @Override
             public @NotNull ClientHttpResponse intercept(
                     @NotNull HttpRequest request,

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateBuilderDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateBuilderDefinition.java
@@ -1,0 +1,38 @@
+package com.decathlon.tzatziki.spring;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+
+
+@ConditionalOnClass(RestTemplateBuilder.class)
+@Component
+public class RestTemplateBuilderDefinition implements HttpInterceptorDefinition<RestTemplateBuilder> {
+    @Override
+    public RestTemplateBuilder rewrite(RestTemplateBuilder webClient) {
+        return webClient.additionalInterceptors(new ClientHttpRequestInterceptor() {
+            @Override
+            public @NotNull ClientHttpResponse intercept(
+                    @NotNull HttpRequest request,
+                    byte @NotNull [] body,
+                    @NotNull ClientHttpRequestExecution execution) throws IOException {
+                HttpRequest proxiedHttpRequest = (HttpRequest) Proxy.newProxyInstance(
+                        request.getClass().getClassLoader(),
+                        new Class[]{HttpRequest.class},
+                        (proxy, method, args) -> switch (method.getName()) {
+                            case "getURI" -> HttpInterceptor.remap(request.getURI());
+                            default -> method.invoke(request, args);
+                        });
+                return execution.execute(proxiedHttpRequest, body);
+            }
+        });
+    }
+}

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateDefinition.java
@@ -1,0 +1,33 @@
+package com.decathlon.tzatziki.spring;
+
+import com.decathlon.tzatziki.utils.Fields;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.net.URI;
+
+
+@ConditionalOnClass(RestTemplate.class)
+@Component
+public class RestTemplateDefinition implements HttpInterceptorDefinition<RestTemplate> {
+    @Override
+    public RestTemplate rewrite(RestTemplate webClient) {
+        ClientHttpRequestFactory requestFactory = Fields.getValue(webClient, "requestFactory");
+        Fields.setValue(webClient, "requestFactory", new ClientHttpRequestFactory() {
+            @SneakyThrows
+            @Override
+            public @NotNull
+            ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) throws IOException {
+                return requestFactory.createRequest(HttpInterceptor.remap(uri), httpMethod);
+            }
+        });
+        return webClient;
+    }
+}

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/RestTemplateDefinition.java
@@ -18,9 +18,9 @@ import java.net.URI;
 @Component
 public class RestTemplateDefinition implements HttpInterceptorDefinition<RestTemplate> {
     @Override
-    public RestTemplate rewrite(RestTemplate webClient) {
-        ClientHttpRequestFactory requestFactory = Fields.getValue(webClient, "requestFactory");
-        Fields.setValue(webClient, "requestFactory", new ClientHttpRequestFactory() {
+    public RestTemplate rewrite(RestTemplate restTemplate) {
+        ClientHttpRequestFactory requestFactory = Fields.getValue(restTemplate, "requestFactory");
+        Fields.setValue(restTemplate, "requestFactory", new ClientHttpRequestFactory() {
             @SneakyThrows
             @Override
             public @NotNull
@@ -28,6 +28,6 @@ public class RestTemplateDefinition implements HttpInterceptorDefinition<RestTem
                 return requestFactory.createRequest(HttpInterceptor.remap(uri), httpMethod);
             }
         });
-        return webClient;
+        return restTemplate;
     }
 }

--- a/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/WebClientBuilderDefinition.java
+++ b/tzatziki-spring/src/main/java/com/decathlon/tzatziki/spring/WebClientBuilderDefinition.java
@@ -1,0 +1,27 @@
+package com.decathlon.tzatziki.spring;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.lang.reflect.Proxy;
+
+
+@ConditionalOnClass(WebClient.Builder.class)
+@Component
+public class WebClientBuilderDefinition implements HttpInterceptorDefinition<WebClient.Builder> {
+    @Override
+    public WebClient.Builder rewrite(WebClient.Builder webClientBuilder) {
+        return webClientBuilder.filter((request, next) -> {
+            ClientRequest proxiedClientRequest = (ClientRequest) Proxy.newProxyInstance(
+                    ClientRequest.class.getClassLoader(),
+                    new Class[]{ClientRequest.class},
+                    (proxy, method, args) -> switch (method.getName()) {
+                        case "url" -> HttpInterceptor.remap(request.url());
+                        default -> method.invoke(request, args);
+                    });
+            return next.exchange(proxiedClientRequest);
+        });
+    }
+}


### PR DESCRIPTION
Resolves #99 
With the version 1.3.9, we've made spring-boot-starter-webflux as _provided_. 
Trying to migrate my app to version 1.3.9 I was forced to add spring-boot-starter-webflux in my dependencies because HttpInterceptor in tzatziki-spring need it.
So I think it's best to use @Conditional spring condition to only inject bean related to web or webflux spring web dependencies depending of the application which is using tzatziki. 
It permit also to remove webflux test dependecies in jpa and kafka modules.

I am not strongly convinced of my approach so I'm open to suggestions. 
I have separate each type of interceptor tzatziki is putting to be sure to only try to intercept classes that are available on the classpath. 