### PR TITLE
Restrict KafkaInterceptor AOP to none final class

### DIFF
--- a/tzatziki-spring-kafka/src/main/java/com/decathlon/tzatziki/kafka/KafkaInterceptor.java
+++ b/tzatziki-spring-kafka/src/main/java/com/decathlon/tzatziki/kafka/KafkaInterceptor.java
@@ -68,7 +68,7 @@ public class KafkaInterceptor {
         }
     }
 
-    @Around("@annotation(org.springframework.context.annotation.Bean)")
+    @Around("@annotation(org.springframework.context.annotation.Bean) && !within(is(FinalType))")
     public Object beanCreation(ProceedingJoinPoint joinPoint) throws Throwable {
         Object bean = joinPoint.proceed();
         if (bean instanceof DefaultKafkaConsumerFactory consumerFactory) {


### PR DESCRIPTION
Similary to #159, there is some AOP issue :
Could not generate CGLIB subclass of class org.springframework.security.config.annotation.method.configuration.PrePostMethodSecurityConfiguration

KafkaInterceptor try to proxy PrePostMethodSecurityConfiguration which is a final class.