### PR TITLE
Bump Spring boot to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/tzatziki-http/pom.xml
+++ b/tzatziki-http/pom.xml
@@ -34,6 +34,12 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.decathlon.tzatziki</groupId>

--- a/tzatziki-jackson/src/main/java/com/decathlon/tzatziki/utils/JacksonMapper.java
+++ b/tzatziki-jackson/src/main/java/com/decathlon/tzatziki/utils/JacksonMapper.java
@@ -1,6 +1,7 @@
 package com.decathlon.tzatziki.utils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
@@ -8,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.Lists;
@@ -29,7 +31,7 @@ public class JacksonMapper implements MapperDelegate {
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
             .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 
-    private static ObjectMapper yaml = configurator.apply(new ObjectMapper(YAMLFactory.builder().disable(YAMLGenerator.Feature.SPLIT_LINES).build()));
+    private static ObjectMapper yaml = configurator.apply(new ObjectMapper(YAMLFactory.builder().enable(YAMLParser.Feature.EMPTY_STRING_AS_NULL).disable(YAMLGenerator.Feature.SPLIT_LINES).build()));
     private static ObjectMapper json = configurator.apply(new ObjectMapper());
     private static ObjectMapper nonDefaultJson = json.copy()
             .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);

--- a/tzatziki-jackson/src/main/java/com/decathlon/tzatziki/utils/JacksonMapper.java
+++ b/tzatziki-jackson/src/main/java/com/decathlon/tzatziki/utils/JacksonMapper.java
@@ -1,7 +1,6 @@
 package com.decathlon.tzatziki.utils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;


### PR DESCRIPTION
Spring boot 3.1.0 imports jackson 2.15 dependency which change YamlFactoryBuilder default parser features. We have to enable YAMLParser.Feature.EMPTY_STRING_AS_NULL to maintain the same behavior.

https://github.com/FasterXML/jackson-dataformats-text/commit/f8f971327dbf4de9638fface7b37303a9691cca6