### PR TITLE
fix: Support arrays with default null in Avro schema

### DIFF
--- a/tzatziki-spring-kafka/src/main/java/com/decathlon/tzatziki/steps/KafkaSteps.java
+++ b/tzatziki-spring-kafka/src/main/java/com/decathlon/tzatziki/steps/KafkaSteps.java
@@ -435,6 +435,12 @@ public class KafkaSteps {
             return ((List<?>) value).stream().map(element -> wrapIn(element, elementType)).collect(Collectors.toList());
         } else if (schema.getType().equals(Schema.Type.ENUM)) {
             return new GenericData.EnumSymbol(schema, value);
+        } else if (schema.getType().equals(Schema.Type.UNION) && value != null) {
+            Schema elementType = schema.getTypes().stream()
+                    .filter(type -> type.getType() != Schema.Type.NULL)
+                    .findFirst()
+                    .orElseThrow();
+            return wrapIn(value, elementType);
         }
         if (value instanceof String string && !schema.getType().equals(Schema.Type.STRING)) {
             value = parseAvro(string, schema);

--- a/tzatziki-spring-kafka/src/test/resources/com/decathlon/tzatziki/steps/kafka.feature
+++ b/tzatziki-spring-kafka/src/test/resources/com/decathlon/tzatziki/steps/kafka.feature
@@ -218,6 +218,39 @@ Feature: to interact with a spring boot service having a connection to a kafka q
       """
     Then we have received 1 message on the topic users-with-group
 
+  Scenario: we can use an avro schema having arrays (with a default value null) of nested records set
+    Given this avro schema:
+      """yml
+      type: record
+      name: Group
+      fields:
+        - name: id
+          type: int
+        - name: name
+          type: string
+        - name: users
+          type:
+            - 'null'
+            - type: array
+              items:
+                name: User
+                type: record
+                fields:
+                  - name: id
+                    type: int
+                  - name: name
+                    type: string
+      """
+    And this Group are consumed from the group-with-users topic:
+      """yml
+      - id: 1
+        name: minions
+        users:
+          - id: 1
+            name: bob
+      """
+    Then we have received 1 message on the topic group-with-users
+
   Scenario: we can use an avro schema having containing arrays
     Given this avro schema:
       """yml


### PR DESCRIPTION
Add support for Avro schemas that include arrays of nested records with a default value of null.