### PR TITLE
Handle multiple db schema clean

### DIFF
--- a/tzatziki-spring-jpa/README.md
+++ b/tzatziki-spring-jpa/README.md
@@ -204,7 +204,7 @@ if you do not want to reset the database between the tests, or you prefer to do 
 
 ```java
 SpringJPASteps.autoclean = false; // to turn it off completely
-SpringJPASteps.schemasToClean =List.of("your-schema1","your-schema2"); // the default is 'public'
+SpringJPASteps.schemasToClean = List.of("your-schema1","your-schema2"); // the default is 'public'
 DatabaseCleaner.addToTablesNotToBeCleaned("config"); // this will prevent the config table to be cleaned
 DatabaseCleaner.resetTablesNotToBeCleanedFilter(); // to purge the previously added tables
 ```

--- a/tzatziki-spring-jpa/README.md
+++ b/tzatziki-spring-jpa/README.md
@@ -204,9 +204,7 @@ if you do not want to reset the database between the tests, or you prefer to do 
 
 ```java
 SpringJPASteps.autoclean = false; // to turn it off completely
-SpringJPASteps.schemasToClean =List.
-
-of("your-schema1","your-schema2"); // the default is 'public'
+SpringJPASteps.schemasToClean =List.of("your-schema1","your-schema2"); // the default is 'public'
 DatabaseCleaner.addToTablesNotToBeCleaned("config"); // this will prevent the config table to be cleaned
 DatabaseCleaner.resetTablesNotToBeCleanedFilter(); // to purge the previously added tables
 ```

--- a/tzatziki-spring-jpa/README.md
+++ b/tzatziki-spring-jpa/README.md
@@ -204,7 +204,9 @@ if you do not want to reset the database between the tests, or you prefer to do 
 
 ```java
 SpringJPASteps.autoclean = false; // to turn it off completely
-SpringJPASteps.schemaToClean = "you-schema"; // the default is 'public'
+SpringJPASteps.schemasToClean =List.
+
+of("your-schema1","your-schema2"); // the default is 'public'
 DatabaseCleaner.addToTablesNotToBeCleaned("config"); // this will prevent the config table to be cleaned
 DatabaseCleaner.resetTablesNotToBeCleanedFilter(); // to purge the previously added tables
 ```

--- a/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
+++ b/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/steps/SpringJPASteps.java
@@ -118,13 +118,15 @@ public class SpringJPASteps {
     }
 
     private Pair<String, String> getTableSchemaAndName(Class<?> clazz) {
-        return Optional.ofNullable(clazz.getAnnotation(PersistenceUtil.getPersistenceClass("Table")))
-                .map(tableAnnotation -> {
-                    String tableName = (String) Optional.ofNullable(AnnotationUtils.getValue((Annotation) tableAnnotation, "name"))
-                            .orElse(Optional.ofNullable(clazz.getAnnotation(org.springframework.data.relational.core.mapping.Table.class))
-                                    .map(org.springframework.data.relational.core.mapping.Table::value).orElse(null)
-                            );
-                    String schemaName = (String) AnnotationUtils.getValue((Annotation) tableAnnotation, "schema");
+        Annotation tableAnnotation = (Annotation) Optional.ofNullable(clazz.getAnnotation(PersistenceUtil.getPersistenceClass("Table")))
+                .orElseGet(() -> clazz.getAnnotation(org.springframework.data.relational.core.mapping.Table.class));
+        return Optional.ofNullable(tableAnnotation)
+                .map(annotation -> {
+                    String tableName = (String) AnnotationUtils.getValue(annotation, "name");
+                    if (StringUtils.isBlank(tableName)) {
+                        tableName = (String) AnnotationUtils.getValue(annotation, "value");
+                    }
+                    String schemaName = (String) AnnotationUtils.getValue(annotation, "schema");
                     return Pair.of(schemaName, tableName);
                 }).orElse(Pair.of(null, null));
     }

--- a/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/utils/DatabaseCleaner.java
+++ b/tzatziki-spring-jpa/src/main/java/com/decathlon/tzatziki/utils/DatabaseCleaner.java
@@ -54,9 +54,14 @@ public class DatabaseCleaner {
     }
 
     @SneakyThrows
+    public static void clean(DataSource dataSource, List<String> schemas) {
+        schemas.forEach(schema -> clean(dataSource, schema));
+    }
+
+    @SneakyThrows
     public static void clean(DataSource dataSource, String schema) {
         executeForAllTables(dataSource, schema, (jdbcTemplate, table)
-                -> jdbcTemplate.update("TRUNCATE %s RESTART IDENTITY CASCADE".formatted(table)));
+                -> jdbcTemplate.update("TRUNCATE %s.%s RESTART IDENTITY CASCADE".formatted(schema, table)));
     }
 
     @SneakyThrows
@@ -65,9 +70,14 @@ public class DatabaseCleaner {
     }
 
     @SneakyThrows
+    public static void setTriggers(DataSource dataSource, List<String> schemas, TriggerStatus status) {
+        schemas.forEach(schema -> setTriggers(dataSource, schema, status));
+    }
+
+    @SneakyThrows
     public static void setTriggers(DataSource dataSource, String schema, TriggerStatus status) {
         executeForAllTables(dataSource, schema, (jdbcTemplate, table)
-                -> jdbcTemplate.update("alter table %s %s trigger all".formatted(table, status)));
+                -> jdbcTemplate.update("alter table %s.%s %s trigger all".formatted(schema, table, status)));
     }
 
     private static void executeForAllTables(DataSource dataSource, String schema, BiConsumer<JdbcTemplate, String> action) throws SQLException {

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/dao/BookDataSpringRepository.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/dao/BookDataSpringRepository.java
@@ -1,0 +1,7 @@
+package com.decathlon.tzatziki.app.dao;
+
+import com.decathlon.tzatziki.app.model.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookDataSpringRepository<T extends Book> extends JpaRepository<T, Integer> {
+}

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/dao/ProductDataSpringRepository.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/dao/ProductDataSpringRepository.java
@@ -1,0 +1,7 @@
+package com.decathlon.tzatziki.app.dao;
+
+import com.decathlon.tzatziki.app.model.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductDataSpringRepository<T extends Product> extends JpaRepository<T, Integer> {
+}

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Book.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Book.java
@@ -1,0 +1,19 @@
+package com.decathlon.tzatziki.app.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "books", schema = "library")
+public class Book {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Integer id;
+
+    @Column(name = "title")
+    String title;
+}

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Product.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/app/model/Product.java
@@ -1,0 +1,19 @@
+package com.decathlon.tzatziki.app.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "products", schema = "store")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Integer id;
+
+    @Column(name = "name")
+    String name;
+}

--- a/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
+++ b/tzatziki-spring-jpa/src/test/java/com/decathlon/tzatziki/steps/TestApplicationSteps.java
@@ -10,6 +10,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -35,6 +36,7 @@ public class TestApplicationSteps {
                     "spring.datasource.username=" + postgres.getUsername(),
                     "spring.datasource.password=" + postgres.getPassword()
             ).applyTo(configurableApplicationContext.getEnvironment());
+            SpringJPASteps.schemasToClean = List.of("public", "library", "store");
         }
     }
 }

--- a/tzatziki-spring-jpa/src/test/resources/com/decathlon/tzatziki/steps/spring-jpa.feature
+++ b/tzatziki-spring-jpa/src/test/resources/com/decathlon/tzatziki/steps/spring-jpa.feature
@@ -308,3 +308,27 @@ Feature: to interact with a spring boot service having a persistence layer
     And it is not true that the evilness table contains:
       | badAttribute |
       | true         |
+
+
+  Scenario: we can manipulate tables from different schemas
+    Given that the books table will contain:
+      | id | title        |
+      | 1  | Harry Potter |
+
+    And that the products table will contain only:
+      | id | name     |
+      | 1  | computer |
+
+    Then the books table contains only:
+      | id | title        |
+      | 1  | Harry Potter |
+
+    And the products table contains only:
+      | id | name     |
+      | 1  | computer |
+
+  Scenario: all schemas are cleared before each scenario
+
+    Then the books table contains nothing
+
+    Then the products table contains nothing

--- a/tzatziki-spring-jpa/src/test/resources/db/migration/V1__schema.sql
+++ b/tzatziki-spring-jpa/src/test/resources/db/migration/V1__schema.sql
@@ -1,0 +1,13 @@
+CREATE SCHEMA library;
+create table library.books
+(
+    id    SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL
+);
+
+CREATE SCHEMA store;
+create table store.products
+(
+    id   SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
Add the ability to specify schemas to clean in a List. 
In the code we prefix table names with schema => (schema.table) in SQL TRUNCATE commands.
We retrieve schema name from entity in the annotation `@Table` like we do for tableName.

Impacts : 
Property `(String) SpringJPASteps.schemaToClean` has been migrated to 
=>  `(List<String>) SpringJPASteps.schemasToClean`

Fix #344 
Fix #340 
