### PR TITLE
✨ feat: template a value in the topic name

### DIFF
--- a/tzatziki-core/src/main/java/com/decathlon/tzatziki/utils/Patterns.java
+++ b/tzatziki-core/src/main/java/com/decathlon/tzatziki/utils/Patterns.java
@@ -20,5 +20,9 @@ public final class Patterns {
     public static final String TYPE_OR_PACKAGE = "((?:[a-z_$][a-z0-9_$\\.]*)*(?:[A-z_$][A-z0-9_$]*))";
     public static final String NUMBER = "([0-9]+(?:\\.[0-9]+)?)";
     public static final String VERIFICATION = "(exactly|at least|at most)";
+    public static final String VARIABLE_OR_TEMPLATE_PATTERN = "(\\{\\{[_a-zA-Z][_\\-.\\w]*\\}\\}|[_a-zA-Z][_\\-.\\w\\[\\]]*|\"[^\"]+\")";
+
+
+
 
 }

--- a/tzatziki-core/src/main/java/com/decathlon/tzatziki/utils/Patterns.java
+++ b/tzatziki-core/src/main/java/com/decathlon/tzatziki/utils/Patterns.java
@@ -20,7 +20,7 @@ public final class Patterns {
     public static final String TYPE_OR_PACKAGE = "((?:[a-z_$][a-z0-9_$\\.]*)*(?:[A-z_$][A-z0-9_$]*))";
     public static final String NUMBER = "([0-9]+(?:\\.[0-9]+)?)";
     public static final String VERIFICATION = "(exactly|at least|at most)";
-    public static final String VARIABLE_OR_TEMPLATE_PATTERN = "(\\{\\{[_a-zA-Z][_\\-.\\w]*\\}\\}|[_a-zA-Z][_\\-.\\w\\[\\]]*|\"[^\"]+\")";
+    public static final String VARIABLE_OR_TEMPLATE_PATTERN = "(\\{\\{[_a-zA-Z][_\\-.\\w]*\\}\\}|"+ VARIABLE_PATTERN +"|\"[^\"]+\")";
 
 
 

--- a/tzatziki-spring-kafka/src/test/resources/com/decathlon/tzatziki/steps/kafka.feature
+++ b/tzatziki-spring-kafka/src/test/resources/com/decathlon/tzatziki/steps/kafka.feature
@@ -540,3 +540,31 @@ Feature: to interact with a spring boot service having a connection to a kafka q
   @ignore
   Scenario: we wait for a poll to occur on a specific topic
     When the json-users-input topic was just polled
+
+  Scenario: we can publish with a templated value in the topic name
+    Given that myTopicName is "template-topic-1"
+    When this user is published on the "{{myTopicName}}" topic:
+      | id | name |
+      | 1  | bob  |
+    Then the template-topic-1 topic contains 1 user
+
+  Scenario: we can check with a templated value in the topic name
+    Given that myTopicName is "template-topic-2"
+    When this json message is published on the template-topic-2 topic:
+      """yml
+      headers:
+        uuid: one-uuid
+      value:
+        id: 1
+        name: bob
+      key: a-key
+      """
+    Then the "{{myTopicName}}" topic contains this json message:
+      """yml
+      headers:
+        uuid: one-uuid
+      value:
+        id: 1
+        name: bob
+      key: a-key
+      """


### PR DESCRIPTION
🎯 This pull request aims to add dynamic management of topic names.

🤔 **Why ?** 
By allowing dynamic templates for topic names, we can replace parts of the topic with changing values. 
This will enable us to create unique topic names based on the environment (or other parameters), facilitating the testing of different conditions and scenarios with a single definition.
_Example: we run tests on ephemeral environments where topic names include a reference to the corresponding pull request : `pr-{pull_request_number}-topic-name`_

💡 That’s why, since this feature exists in different HTTP steps, it would be useful to also have the ability to use templates for the topic names in Kafka.

🙏🏼 Thank you for taking the time to review these changes!

