### PR TITLE
fix: catch errors in type parsing when there are multiple candidates

### DIFF
--- a/tzatziki-common/src/main/java/com/decathlon/tzatziki/utils/TypeParser.java
+++ b/tzatziki-common/src/main/java/com/decathlon/tzatziki/utils/TypeParser.java
@@ -76,8 +76,15 @@ public class TypeParser {
             default -> classes()
                     .stream()
                     .filter(clazz -> clazz.getName().equals(n) || clazz.getSimpleName().equals(n))
+                    .map((ClassPath.ClassInfo classInfo) -> {
+                        try {
+                            return (Type) classInfo.load();
+                        } catch (NoClassDefFoundError e) {
+                            return null;
+                        }
+                    })
+                    .filter(Objects::nonNull)
                     .findFirst()
-                    .map((ClassPath.ClassInfo classInfo) -> (Type) classInfo.load())
                     .orElseGet(() -> {
                         try {
                             return Class.forName(n);


### PR DESCRIPTION
### Issue:

Since upgrading to Spring Boot 3.4, we encountered issues with the tzatziki step:

> "receive a status X and a Response"

The error originates from the method TypeParser.parseType, which attempts to load a class that is not present in the classpath, causing a failure in the test execution.

### Fix:

I added error handling to catch this specific case and allow the correct class to be loaded afterward. This prevents the test from failing due to an unavailable class while ensuring the expected response is properly processed.

Let me know if any additional changes are needed! 🚀