### PR TITLE
Revert "chore(deps): bump org.apache.maven.plugins:maven-surefire-plugin from 3.5.2 to 3.5.3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.2</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/tzatziki-testng/pom.xml
+++ b/tzatziki-testng/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.2</version>
                 <configuration>
                     <parallel>methods</parallel>
                     <threadCount>10</threadCount>
@@ -80,7 +80,7 @@
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
                         <artifactId>surefire-testng</artifactId>
-                        <version>3.5.3</version>
+                        <version>3.5.2</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Seems to be the reason the CI is not failing in case of Cucumber test error

Reverts Decathlon/tzatziki#495