### PR TITLE
fix: mock multiple params with same name using WireMock.including

### DIFF
--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/Interaction.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/Interaction.java
@@ -17,13 +17,14 @@ import io.restassured.specification.RequestSpecification;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.entity.ContentType;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 import static com.decathlon.tzatziki.utils.Types.rawTypeOf;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -93,12 +94,8 @@ public class Interaction {
             if (uri.group(5) != null) {
                 HttpWiremockUtils.parseQueryParams(uri.group(5), false)
                         .stream()
-                        .collect(() -> new LinkedHashMap<String, List<String>>(), (map, pair) ->
-                                        map.merge(pair.getKey(), new ArrayList<>(List.of(pair.getValue())), (oldV, newV) -> {
-                                            oldV.addAll(newV);
-                                            return oldV;
-                                        }),
-                                LinkedHashMap::putAll)
+                        .collect(Collectors.groupingBy(Pair::getKey, LinkedHashMap::new,
+                                Collectors.mapping(Pair::getValue, Collectors.toList())))
                         .forEach((key, value) -> {
                             if (value.size() > 1) {
                                 request.withQueryParam(key, including(value.toArray(new String[0])));
@@ -276,5 +273,3 @@ public class Interaction {
         }
     }
 }
-
-

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -778,6 +778,36 @@ Feature: to interact with an http service and setup mocks
       | item=3               | NOT_FOUND_404 |
       | item=1&item=2&item=3 | OK_200        |
 
+  Scenario: repeated query parameters are exposed as an array in templates
+    Given that calling "http://backend/collect?item=1&item=2" will return:
+      """yml
+      items:
+        \{{#each request.query.item}}
+        - \{{this}}
+        \{{/each}}
+      """
+    When we call "http://backend/collect?item=1&item=2"
+    Then we receive:
+      """yml
+      items:
+        - 1
+        - 2
+      """
+
+  Scenario: later stub overrides earlier stub for same endpoint
+    Given that calling "http://backend/hello?name=(.*)" will return:
+      """yml
+      message: regex $1
+      """
+    And that calling "http://backend/hello?name=bob" will return:
+      """yml
+      message: literal
+      """
+    When we call "http://backend/hello?name=bob"
+    Then we receive:
+      """yml
+      message: literal
+      """
 
   Scenario: The order of items in a list should not be a matching criteria when we give in a payload of a given type (prevent exact String comparison)
     # To specify we don't want the order of an array to have an influence we can either:
@@ -1621,6 +1651,4 @@ Feature: to interact with an http service and setup mocks
       | id_1 |
       | id_2 |
       | id_3 |
-
-
 


### PR DESCRIPTION
Actual behavior is to only stub the last query param, if we have multiple params with the same name.

New behavior is to stub all query params, using the WireMock.including method