### PR TITLE
feat(wiremock): add wiremock JSON stubbing support

### DIFF
--- a/tzatziki-http/README.md
+++ b/tzatziki-http/README.md
@@ -465,12 +465,12 @@ Given the wiremock:
 You can specify the protocol (http or https) when defining the stub:
 
 ```gherkin
-Given the https wiremock:
+Given the wiremock:
   """
   {
     "request": {
       "method": "GET",
-      "url": "/backend/secure"
+      "url": "https://backend/secure"
     },
     "response": {
       "status": 200,
@@ -504,12 +504,12 @@ Given the wiremock with id "GET_PET" is:
 
 # Later in the scenario, replace the mock with the same ID
 # note the protocol change as well
-Given the https wiremock with id "GET_PET" is: 
+Given the wiremock with id "GET_PET" is: 
   """
   {
     "request": {
       "method": "POST",
-      "url": "/backend/pet/dog"
+      "url": "https://backend/pet/dog"
     },
     "response": {
       "status": 500,

--- a/tzatziki-http/README.md
+++ b/tzatziki-http/README.md
@@ -441,10 +441,10 @@ In addition to the simplified mocking syntax described above, you can use WireMo
 
 ##### Basic Usage
 
-Use the `the following wiremock:` step to define a stub using WireMock's JSON format:
+Use the `the wiremock:` step to define a stub using WireMock's JSON format:
 
 ```gherkin
-Given the following wiremock:
+Given the wiremock:
   """
   {
     "request": {
@@ -465,7 +465,7 @@ Given the following wiremock:
 You can specify the protocol (http or https) when defining the stub:
 
 ```gherkin
-Given the following https wiremock:
+Given the https wiremock:
   """
   {
     "request": {
@@ -482,13 +482,13 @@ Given the following https wiremock:
 
 If no protocol is specified, `http` is used by default.
 
-##### Using WireMock IDs
+##### Using WireMock IDs to Update Stubs
 
-You can assign an ID to a WireMock stub to edit or remove it later:
+You can assign an ID to a WireMock stub and redefine it later in your scenario. When you redefine a stub with the same ID, the old stub is automatically removed and replaced with the new definition:
 
 ```gherkin
-# Set a mock with an ID
-Given the following wiremock with id "GET_PET":
+# Set initial mock with an ID
+Given the wiremock with id "GET_PET" is:
   """
   {
     "request": {
@@ -501,20 +501,15 @@ Given the following wiremock with id "GET_PET":
     }
   }
   """
-```
 
-##### Editing WireMock Stubs
-
-Use the ID to edit the stub later in your scenario:
-
-```gherkin
-# Edit the mock using its ID
-When we edit the wiremock with id "GET_PET" to https:
+# Later in the scenario, replace the mock with the same ID
+# note the protocol change as well
+Given the https wiremock with id "GET_PET" is: 
   """
   {
     "request": {
       "method": "POST",
-      "url": "backend/pet/dog"
+      "url": "/backend/pet/dog"
     },
     "response": {
       "status": 500,
@@ -527,21 +522,13 @@ When we edit the wiremock with id "GET_PET" to https:
   """
 ```
 
-##### Removing WireMock Stubs
-
-Remove a stub by its ID:
-
-```gherkin
-When we remove the wiremock with id "GET_PET"
-```
-
 ##### Template Variables in WireMock Stubs
 
 You can use Cucumber context variables in your WireMock JSON definitions:
 
 ```gherkin
 Given that value is "dog"
-Given the following wiremock:
+Given the wiremock:
   """
   {
     "request": {
@@ -566,7 +553,7 @@ Then we received a status OK_200 and:
 You can use WireMock's Handlebars helpers in your stubs (note the escaped braces `\{{`):
 
 ```gherkin
-Given the following wiremock:
+Given the wiremock:
   """
   {
     "request": {

--- a/tzatziki-http/README.md
+++ b/tzatziki-http/README.md
@@ -435,6 +435,159 @@ Scenario: Successive calls to a mocked endpoint can reply different responses
     Then getting on "http://backend/time" returns a status 404
 ```
 
+#### WireMock JSON Stubbing
+
+In addition to the simplified mocking syntax described above, you can use WireMock's native JSON stub mapping format directly. This gives you access to all of WireMock's advanced features while still benefiting from Tzatziki's URL remapping and test isolation.
+
+##### Basic Usage
+
+Use the `the following wiremock:` step to define a stub using WireMock's JSON format:
+
+```gherkin
+Given the following wiremock:
+  """
+  {
+    "request": {
+      "method": "GET",
+      "url": "/backend/pet"
+    },
+    "response": {
+      "status": 200,
+      "body": "Hello pet",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+  """
+```
+
+You can specify the protocol (http or https) when defining the stub:
+
+```gherkin
+Given the following https wiremock:
+  """
+  {
+    "request": {
+      "method": "GET",
+      "url": "/backend/secure"
+    },
+    "response": {
+      "status": 200,
+      "body": "Secure data"
+    }
+  }
+  """
+```
+
+If no protocol is specified, `http` is used by default.
+
+##### Using WireMock IDs
+
+You can assign an ID to a WireMock stub to edit or remove it later:
+
+```gherkin
+# Set a mock with an ID
+Given the following wiremock with id "GET_PET":
+  """
+  {
+    "request": {
+      "method": "GET",
+      "url": "/backend/pet"
+    },
+    "response": {
+      "status": 200,
+      "body": "Hello pet"
+    }
+  }
+  """
+```
+
+##### Editing WireMock Stubs
+
+Use the ID to edit the stub later in your scenario:
+
+```gherkin
+# Edit the mock using its ID
+When we edit the wiremock with id "GET_PET" to https:
+  """
+  {
+    "request": {
+      "method": "POST",
+      "url": "backend/pet/dog"
+    },
+    "response": {
+      "status": 500,
+      "body": "New doggo creation failed",
+      "headers": {
+        "Content-Type": "application/text"
+      }
+    }
+  }
+  """
+```
+
+##### Removing WireMock Stubs
+
+Remove a stub by its ID:
+
+```gherkin
+When we remove the wiremock with id "GET_PET"
+```
+
+##### Template Variables in WireMock Stubs
+
+You can use Cucumber context variables in your WireMock JSON definitions:
+
+```gherkin
+Given that value is "dog"
+Given the following wiremock:
+  """
+  {
+    "request": {
+      "method": "GET",
+      "url": "/backend/pet/{{value}}"
+    },
+    "response": {
+      "status": 200,
+      "body": "Hello {{value}}"
+    }
+  }
+  """
+When we get on "http://backend/pet/dog"
+Then we received a status OK_200 and:
+  """
+  Hello dog
+  """
+```
+
+##### WireMock Handlebars Helpers
+
+You can use WireMock's Handlebars helpers in your stubs (note the escaped braces `\{{`):
+
+```gherkin
+Given the following wiremock:
+  """
+  {
+    "request": {
+      "method": "GET",
+      "urlPattern": "/backend/pet\\?name=(.*)"
+    },
+    "response": {
+      "status": 200,
+      "body": "Hello \{{request.query.name}}"
+    }
+  }
+  """
+When we get on "http://backend/pet?name=dog"
+Then we received a status OK_200 and:
+  """
+  Hello dog
+  """
+```
+
+For more information on WireMock's JSON stubbing format and available features, see the [WireMock Stubbing documentation](https://wiremock.org/docs/stubbing/).
+
 #### URL remapping
 
 Each mocked host will be dynamically remapped on the local WireMock server.

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -649,7 +649,6 @@ public class HttpSteps {
             // Remove the old mapping if present
             if (StringUtils.isNotBlank(mockId)) {
                 if (WIREMOCK_STUBS.containsKey(mockId) && wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).isPresent()) {
-                    HttpWiremockUtils.removeMocked(wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).getItem().getRequest().getUrl());
                     wireMockServer.removeStub(WIREMOCK_STUBS.get(mockId));
                 }
                 WIREMOCK_STUBS.put(mockId, stubMapping.getId());

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -635,10 +635,10 @@ public class HttpSteps {
      * <p>It uses the wiremock JSON stubbing format, for more information see <a href="https://wiremock.org/docs/stubbing/">WireMock — Stubbing documentation</a>
      * @param guard Tzatziki guard
      * @param unresolvedProtocol https, http or blank
-     * @param unresolvedMockId A unique ID that can be used to edit or remove this stub later
+     * @param unresolvedMockId A unique ID that can be used to replace this stub later
      * @param unresolvedWiremock the WireMock stubbing
      */
-    @Given(THAT + GUARD + "the following (?:(https|http) )?wiremock(?: with id " + QUOTED_CONTENT + ")?:$")
+    @Given(THAT + GUARD + "the (?:(https|http) )?wiremock(?: with id " + QUOTED_CONTENT + ")?(?: is)?:$")
     public void set_a_wiremock(Guard guard, String unresolvedProtocol, String unresolvedMockId, String unresolvedWiremock) {
         guard.in(objects, () -> {
             final String wiremockSpecJson = objects.resolve(unresolvedWiremock);
@@ -646,44 +646,17 @@ public class HttpSteps {
             StubMapping stubMapping = StubMapping.buildFrom(wiremockSpecJson);
             final String protocol = StringUtils.isBlank(unresolvedProtocol) ? "http" : unresolvedProtocol;
 
-            remapUrlOfStubMapping(stubMapping, protocol);
+            addToMockedUrlOfStubMapping(stubMapping, protocol);
+
+            // Remove the old mapping if present
             if (StringUtils.isNotBlank(mockId)) {
+                if (WIREMOCK_STUBS.containsKey(mockId) && wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).isPresent()) {
+                    HttpWiremockUtils.removeMocked(wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).getItem().getRequest().getUrl());
+                    wireMockServer.removeStub(WIREMOCK_STUBS.get(mockId));
+                }
                 WIREMOCK_STUBS.put(mockId, stubMapping.getId());
             }
             wireMockServer.addStubMapping(stubMapping);
-        });
-    }
-
-    @Given(THAT + GUARD + "we edit the wiremock with id " + QUOTED_CONTENT + "(?: to (https|http))?:$")
-    public void edit_a_wiremock(Guard guard, String unresolvedMockId, String unresolvedProtocol, String unresolvedWiremock) {
-        guard.in(objects, () -> {
-            final String wiremockSpecJson = objects.resolve(unresolvedWiremock);
-            final String mockId = objects.resolve(unresolvedMockId);
-            StubMapping stubMapping = StubMapping.buildFrom(wiremockSpecJson);
-            final String protocol = StringUtils.isBlank(unresolvedProtocol) ? "http" : unresolvedProtocol;
-
-            if (WIREMOCK_STUBS.containsKey(mockId) && wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).isPresent()) {
-                HttpWiremockUtils.removeMocked(wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).getItem().getRequest().getUrl());
-            }
-
-            remapUrlOfStubMapping(stubMapping, protocol);
-            stubMapping.setId(WIREMOCK_STUBS.get(mockId));
-
-            wireMockServer.editStubMapping(stubMapping);
-        });
-    }
-
-    @Given(THAT + GUARD + "we remove the wiremock with id " + QUOTED_CONTENT + "$")
-    public void remove_a_wiremock(Guard guard, String unresolvedMockId) {
-        guard.in(objects, () -> {
-            final String mockId = objects.resolve(unresolvedMockId);
-            UUID stubId = WIREMOCK_STUBS.get(mockId);
-            if (stubId == null) {
-                log.warn("No WireMock stub found with id '{}'", mockId);
-                return;
-            }
-            wireMockServer.removeStub(stubId);
-            WIREMOCK_STUBS.remove(mockId);
         });
     }
 }

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -673,7 +673,7 @@ public class HttpSteps {
         });
     }
 
-    @Given(THAT + GUARD + "we remove the wiremock with id " + QUOTED_CONTENT)
+    @Given(THAT + GUARD + "we remove the wiremock with id " + QUOTED_CONTENT + "$")
     public void remove_a_wiremock(Guard guard, String unresolvedMockId) {
         guard.in(objects, () -> {
             final String mockId = objects.resolve(unresolvedMockId);

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -16,6 +16,7 @@ import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.verification.NearMiss;
 import com.github.tomakehurst.wiremock.verification.diff.Diff;
 import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
@@ -27,6 +28,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.restassured.specification.RequestSpecification;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
@@ -76,6 +78,8 @@ public class HttpSteps {
     private final Map<String, List<Pair<String, String>>> headersByUsername = new LinkedHashMap<>();
     private UnaryOperator<String> relativeUrlRewriter = UnaryOperator.identity();
     public static final Set<String> MOCKED_PATHS = new LinkedHashSet<>();
+    public static final Map<String, UUID> WIREMOCK_STUBS = new HashMap<>();
+    public static final String OBJECT_STEPS_RESPONSE_KEY = "_response";
     public static Integer localPort;
     public static boolean resetMocksBetweenTests = true;
     private static final PlainTextStubNotMatchedRenderer notMatchedRenderer = new PlainTextStubNotMatchedRenderer(Extensions.NONE);
@@ -227,7 +231,7 @@ public class HttpSteps {
 
     @Then(THAT + GUARD + A_USER + "receive(?:s|d)? a (?:" + TYPE + " )?" + VARIABLE + "$")
     public void we_save_the_payload_as(Guard guard, Type type, String variable) {
-        guard.in(objects, () -> objects.add(variable, objects.resolvePossiblyTypedObject(type, objects.<Response>get("_response").body.payload)));
+        guard.in(objects, () -> objects.add(variable, objects.resolvePossiblyTypedObject(type, objects.<Response>get(OBJECT_STEPS_RESPONSE_KEY).body.payload)));
     }
 
     @Then(THAT + GUARD + "(" + A_USER + ")sending on " + QUOTED_CONTENT + " receives" + COMPARING_WITH + ":$")
@@ -236,7 +240,7 @@ public class HttpSteps {
             String interactionStr = objects.resolve(content);
             Interaction interaction = Mapper.read(interactionStr, Interaction.class);
             send(user, path, interaction.request);
-            comparison.compare(objects.get("_response"), Mapper.read(interactionStr, Map.class).get("response"));
+            comparison.compare(objects.get(OBJECT_STEPS_RESPONSE_KEY), Mapper.read(interactionStr, Map.class).get("response"));
         });
     }
 
@@ -306,7 +310,7 @@ public class HttpSteps {
     public void call(Guard guard, String user, Method method, String path) {
         guard.in(objects, () -> {
             try {
-                objects.add("_response", Response.fromResponse(as(user).request(method.name(), rewrite(target(objects.resolve(path))))));
+                objects.add(OBJECT_STEPS_RESPONSE_KEY, Response.fromResponse(as(user).request(method.name(), rewrite(target(objects.resolve(path))))));
             } catch (Exception e) {
                 throw new AssertionError(e.getMessage(), e);
             }
@@ -316,7 +320,7 @@ public class HttpSteps {
     @Then(THAT + GUARD + A_USER + "receive(?:s|d)?" + COMPARING_WITH + "(?: " + A + TYPE + ")?:$")
     public void we_receive(Guard guard, Comparison comparison, Type type, String content) {
         guard.in(objects, () -> {
-            Response response = objects.get("_response");
+            Response response = objects.get(OBJECT_STEPS_RESPONSE_KEY);
             String payload = objects.resolve(content);
             if (Response.class.equals(type)) {
                 Map<String, Object> expected = Mapper.read(objects.resolve(payload));
@@ -368,7 +372,7 @@ public class HttpSteps {
     @Then(THAT + GUARD + A_USER + "receive(?:s|d)? a status " + STATUS + "$")
     public void we_receive_a_status(Guard guard, HttpStatusCode status) {
         guard.in(objects, () -> {
-            Response response = objects.get("_response");
+            Response response = objects.get(OBJECT_STEPS_RESPONSE_KEY);
             withFailMessage(() -> assertThat(response.status).isEqualTo(status.name()), () -> """
                     Expected status code <%s> but was <%s>
                     payload:
@@ -589,7 +593,7 @@ public class HttpSteps {
 
     public void send(String user, String path, Request request) {
         try {
-            objects.add("_response", Response.fromResponse(request.send(as(user), rewrite(target(objects.resolve(path))), objects)));
+            objects.add(OBJECT_STEPS_RESPONSE_KEY, Response.fromResponse(request.send(as(user), rewrite(target(objects.resolve(path))), objects)));
         } catch (Exception e) {
             throw new AssertionError(e.getMessage(), e);
         }
@@ -625,5 +629,61 @@ public class HttpSteps {
     public void we_dont_reset_mocks_between_tests(Guard guard) {
         guard.in(objects, () -> HttpSteps.resetMocksBetweenTests = false);
     }
-    
+
+    /**
+     * The following step allows to set up a WireMock stub by providing its specification as a JSON string.
+     * <p>It uses the wiremock JSON stubbing format, for more information see <a href="https://wiremock.org/docs/stubbing/">WireMock — Stubbing documentation</a>
+     * @param guard Tzatziki guard
+     * @param unresolvedProtocol https, http or blank
+     * @param unresolvedMockId A unique ID that can be used to edit or remove this stub later
+     * @param unresolvedWiremock the WireMock stubbing
+     */
+    @Given(THAT + GUARD + "the following (?:(https|http) )?wiremock(?: with id " + QUOTED_CONTENT + ")?:$")
+    public void set_a_wiremock(Guard guard, String unresolvedProtocol, String unresolvedMockId, String unresolvedWiremock) {
+        guard.in(objects, () -> {
+            final String wiremockSpecJson = objects.resolve(unresolvedWiremock);
+            final String mockId = objects.resolve(unresolvedMockId);
+            StubMapping stubMapping = StubMapping.buildFrom(wiremockSpecJson);
+            final String protocol = StringUtils.isBlank(unresolvedProtocol) ? "http" : unresolvedProtocol;
+
+            remapUrlOfStubMapping(stubMapping, protocol);
+            if (StringUtils.isNotBlank(mockId)) {
+                WIREMOCK_STUBS.put(mockId, stubMapping.getId());
+            }
+            wireMockServer.addStubMapping(stubMapping);
+        });
+    }
+
+    @Given(THAT + GUARD + "we edit the wiremock with id " + QUOTED_CONTENT + "(?: to (https|http))?:$")
+    public void edit_a_wiremock(Guard guard, String unresolvedMockId, String unresolvedProtocol, String unresolvedWiremock) {
+        guard.in(objects, () -> {
+            final String wiremockSpecJson = objects.resolve(unresolvedWiremock);
+            final String mockId = objects.resolve(unresolvedMockId);
+            StubMapping stubMapping = StubMapping.buildFrom(wiremockSpecJson);
+            final String protocol = StringUtils.isBlank(unresolvedProtocol) ? "http" : unresolvedProtocol;
+
+            if (WIREMOCK_STUBS.containsKey(mockId) && wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).isPresent()) {
+                HttpWiremockUtils.removeMocked(wireMockServer.getStubMapping(WIREMOCK_STUBS.get(mockId)).getItem().getRequest().getUrl());
+            }
+
+            remapUrlOfStubMapping(stubMapping, protocol);
+            stubMapping.setId(WIREMOCK_STUBS.get(mockId));
+
+            wireMockServer.editStubMapping(stubMapping);
+        });
+    }
+
+    @Given(THAT + GUARD + "we remove the wiremock with id " + QUOTED_CONTENT)
+    public void remove_a_wiremock(Guard guard, String unresolvedMockId) {
+        guard.in(objects, () -> {
+            final String mockId = objects.resolve(unresolvedMockId);
+            UUID stubId = WIREMOCK_STUBS.get(mockId);
+            if (stubId == null) {
+                log.warn("No WireMock stub found with id '{}'", mockId);
+                return;
+            }
+            wireMockServer.removeStub(stubId);
+            WIREMOCK_STUBS.remove(mockId);
+        });
+    }
 }

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/steps/HttpSteps.java
@@ -634,19 +634,17 @@ public class HttpSteps {
      * The following step allows to set up a WireMock stub by providing its specification as a JSON string.
      * <p>It uses the wiremock JSON stubbing format, for more information see <a href="https://wiremock.org/docs/stubbing/">WireMock — Stubbing documentation</a>
      * @param guard Tzatziki guard
-     * @param unresolvedProtocol https, http or blank
      * @param unresolvedMockId A unique ID that can be used to replace this stub later
      * @param unresolvedWiremock the WireMock stubbing
      */
-    @Given(THAT + GUARD + "the (?:(https|http) )?wiremock(?: with id " + QUOTED_CONTENT + ")?(?: is)?:$")
-    public void set_a_wiremock(Guard guard, String unresolvedProtocol, String unresolvedMockId, String unresolvedWiremock) {
+    @Given(THAT + GUARD + "the wiremock(?: with id " + QUOTED_CONTENT + ")?(?: is)?:$")
+    public void set_a_wiremock(Guard guard, String unresolvedMockId, String unresolvedWiremock) {
         guard.in(objects, () -> {
             final String wiremockSpecJson = objects.resolve(unresolvedWiremock);
             final String mockId = objects.resolve(unresolvedMockId);
             StubMapping stubMapping = StubMapping.buildFrom(wiremockSpecJson);
-            final String protocol = StringUtils.isBlank(unresolvedProtocol) ? "http" : unresolvedProtocol;
 
-            addToMockedUrlOfStubMapping(stubMapping, protocol);
+            addToMockedUrlOfStubMapping(stubMapping);
 
             // Remove the old mapping if present
             if (StringUtils.isNotBlank(mockId)) {

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpUtils.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpUtils.java
@@ -4,11 +4,12 @@ import com.decathlon.tzatziki.steps.HttpSteps;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
-import static com.decathlon.tzatziki.steps.HttpSteps.MOCKED_PATHS;
-import static com.decathlon.tzatziki.steps.HttpSteps.wireMockServer;
+import static com.decathlon.tzatziki.steps.HttpSteps.*;
 import static com.decathlon.tzatziki.utils.Comparison.CONTAINS;
 
 @SuppressWarnings("java:S1118")
@@ -107,6 +108,7 @@ public class HttpUtils {
     public static void reset() {
         wireMockServer.resetAll();
         MOCKED_PATHS.clear();
+        WIREMOCK_STUBS.clear();
         PERSISTENT_MOCKS.forEach(wireMockServer::stubFor);
     }
 

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
@@ -112,7 +112,7 @@ public class HttpWiremockUtils {
      * @param stubMapping the WireMock stub mapping whose request URL should be remapped; mutated in place
      * @param protocol    the scheme to prepend ({@code "http"} or {@code "https"})
      */
-    public static void remapUrlOfStubMapping(StubMapping stubMapping, final String protocol) {
+    public static void addToMockedUrlOfStubMapping(StubMapping stubMapping, final String protocol) {
         final RequestPattern requestPattern = stubMapping.getRequest();
         Stream.<Pair<String, Function<String, UrlPattern>>>of(
                 Pair.of(requestPattern.getUrlPath(),         WireMock::urlPathEqualTo),

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
@@ -110,9 +110,8 @@ public class HttpWiremockUtils {
      * <p>If none of those fields is set, no mutation is performed and a warning is logged.
      *
      * @param stubMapping the WireMock stub mapping whose request URL should be remapped; mutated in place
-     * @param protocol    the scheme to prepend ({@code "http"} or {@code "https"})
      */
-    public static void addToMockedUrlOfStubMapping(StubMapping stubMapping, final String protocol) {
+    public static void addToMockedUrlOfStubMapping(StubMapping stubMapping) {
         final RequestPattern requestPattern = stubMapping.getRequest();
         Stream.<Pair<String, Function<String, UrlPattern>>>of(
                 Pair.of(requestPattern.getUrlPath(),         WireMock::urlPathEqualTo),
@@ -125,7 +124,7 @@ public class HttpWiremockUtils {
         .findFirst()
         .ifPresentOrElse(
                 pair -> {
-                    final String remappedMockUrl = HttpWiremockUtils.mocked(protocol + "://" + StringUtils.removeStart(pair.getLeft(), '/'));
+                    final String remappedMockUrl = HttpWiremockUtils.mocked(pair.getLeft());
                     stubMapping.setRequest(RequestPatternBuilder.like(requestPattern)
                             .withUrl(pair.getRight().apply(remappedMockUrl))
                             .build());

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
@@ -1,9 +1,15 @@
 package com.decathlon.tzatziki.utils;
 
 import com.decathlon.tzatziki.steps.HttpSteps;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.MultiValue;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.google.common.base.Splitter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -13,12 +19,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static com.decathlon.tzatziki.steps.HttpSteps.MOCKED_PATHS;
 import static java.util.stream.Collectors.toMap;
 
+@Slf4j
 @SuppressWarnings({
         "java:S5960",// Address Sonar warning: False positive assertion check on non-production code.
         "java:S1118" // Utility class should not have constructor
@@ -36,6 +45,13 @@ public class HttpWiremockUtils {
             return remapAsMocked(uri);
         }
         return path;
+    }
+
+    public static void removeMocked(String path) {
+        Matcher uri = match(path);
+        if (uri.group(2) != null) {
+            MOCKED_PATHS.remove(uri.group(1) + "://" + uri.group(2));
+        }
     }
 
     public static Matcher match(String path) {
@@ -80,5 +96,41 @@ public class HttpWiremockUtils {
                     .toList();
         }
         return new ArrayList<>();
+    }
+
+    /**
+     * Remaps the request URL of a WireMock stub mapping so that it is served under the internal
+     * {@code /_mocked/<protocol>/<host><original_path>} prefix used by tzatziki.
+     *
+     * <p>This method mutates the given {@code stubMapping} in place: the first non-null URL field
+     * found among {@code url}, {@code urlPath}, {@code urlPattern}, {@code urlPathPattern} and
+     * {@code urlPathTemplate} is rewritten, preserving its match semantics (exact, path-only,
+     * regex, …). See <a href="https://wiremock.org/docs/request-matching/">WireMock — request matching</a>.
+     *
+     * <p>If none of those fields is set, no mutation is performed and a warning is logged.
+     *
+     * @param stubMapping the WireMock stub mapping whose request URL should be remapped; mutated in place
+     * @param protocol    the scheme to prepend ({@code "http"} or {@code "https"})
+     */
+    public static void remapUrlOfStubMapping(StubMapping stubMapping, final String protocol) {
+        final RequestPattern requestPattern = stubMapping.getRequest();
+        Stream.<Pair<String, Function<String, UrlPattern>>>of(
+                Pair.of(requestPattern.getUrlPath(),         WireMock::urlPathEqualTo),
+                Pair.of(requestPattern.getUrl(),             WireMock::urlEqualTo),
+                Pair.of(requestPattern.getUrlPattern(),      WireMock::urlMatching),
+                Pair.of(requestPattern.getUrlPathPattern(),  WireMock::urlPathMatching),
+                Pair.of(requestPattern.getUrlPathTemplate(), WireMock::urlPathTemplate)
+        )
+        .filter(pair -> pair.getLeft() != null)
+        .findFirst()
+        .ifPresentOrElse(
+                pair -> {
+                    final String remappedMockUrl = HttpWiremockUtils.mocked(protocol + "://" + StringUtils.removeStart(pair.getLeft(), '/'));
+                    stubMapping.setRequest(RequestPatternBuilder.like(requestPattern)
+                            .withUrl(pair.getRight().apply(remappedMockUrl))
+                            .build());
+                },
+                () -> log.warn("WireMock stub [id={}] has no recognizable URL field (url, urlPath, urlPattern, urlPathPattern, urlPathTemplate) — the request URL will not be remapped to /_mocked/<protocol>/<host>", stubMapping.getId())
+        );
     }
 }

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/HttpWiremockUtils.java
@@ -47,13 +47,6 @@ public class HttpWiremockUtils {
         return path;
     }
 
-    public static void removeMocked(String path) {
-        Matcher uri = match(path);
-        if (uri.group(2) != null) {
-            MOCKED_PATHS.remove(uri.group(1) + "://" + uri.group(2));
-        }
-    }
-
     public static Matcher match(String path) {
         Matcher uri = URI.matcher(path);
         if (!uri.matches()) {

--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/UrlPatternTransformer.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/UrlPatternTransformer.java
@@ -28,7 +28,7 @@ public class UrlPatternTransformer implements ResponseTransformerV2 {
     }
 
     private String replaceCapturingGroup(String responsePayload, ServeEvent serveEvent) {
-        if (responsePayload != null) {
+        if (responsePayload != null && serveEvent.getStubMapping().getRequest().getUrlMatcher().isRegex()) {
             String expected = serveEvent.getStubMapping().getRequest().getUrlMatcher().getPattern().getExpected();
             if (serveEvent.getStubMapping().getRequest().getQueryParameters() != null) {
                 expected += "\\?" + getExpectedFromQueryParameters(serveEvent);

--- a/tzatziki-http/src/test/java/com/decathlon/tzatziki/utils/HttpUtilsTest.java
+++ b/tzatziki-http/src/test/java/com/decathlon/tzatziki/utils/HttpUtilsTest.java
@@ -1,5 +1,7 @@
 package com.decathlon.tzatziki.utils;
 
+import com.decathlon.tzatziki.steps.HttpSteps;
+import com.decathlon.tzatziki.steps.ObjectSteps;
 import com.decathlon.tzatziki.utils.Interaction.Body;
 import com.decathlon.tzatziki.utils.Interaction.Request;
 import com.decathlon.tzatziki.utils.Interaction.Response;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 
 import static com.decathlon.tzatziki.utils.HttpUtils.*;
@@ -106,6 +109,61 @@ class HttpUtilsTest {
         @Test
         void doNotRemapWhenNotMocked() {
             assertThat(target("http://example.com/api/path")).isEqualTo("http://example.com/api/path");
+        }
+
+
+        @Test
+        @DisplayName("WireMock tests should add and update in WIREMOCK_STUBS map")
+        void shouldAddAndUpdateWireMockStubsInMap() {
+            // Given
+            HttpSteps httpSteps = new HttpSteps(new ObjectSteps());
+            final String jsonStub = """
+                    {
+                      "request": {
+                        "method": "GET",
+                        "url": "https://backend/pet"
+                      },
+                      "response": {
+                        "status": 200,
+                        "body": "Hello pet",
+                        "headers": {
+                          "Content-Type": "application/json"
+                        }
+                      }
+                    }""";
+            // When we set a new wiremock
+            httpSteps.set_a_wiremock(Guard.always(), "TEST_GET", jsonStub);
+            // Then
+            assertThat(HttpSteps.WIREMOCK_STUBS).containsKey("TEST_GET")
+                    .extractingByKey("TEST_GET")
+                    .isInstanceOf(UUID.class);
+            // WIREMOCK_STUBS and the mock server share a common UUID
+            assertThat(HttpSteps.wireMockServer.getStubMapping(HttpSteps.WIREMOCK_STUBS.get("TEST_GET")).isPresent()).isTrue();
+            assertThat(HttpSteps.MOCKED_PATHS).contains("https://backend");
+            // Given
+            final UUID oldStubId = HttpSteps.WIREMOCK_STUBS.get("TEST_GET");
+            final String newJsonStub = """
+                    {
+                      "request": {
+                        "method": "GET",
+                        "url": "http://backend/pet"
+                      },
+                      "response": {
+                        "status": 200
+                      }
+                    }""";
+            // When we overwrite an existing wiremock
+            httpSteps.set_a_wiremock(Guard.always(), "TEST_GET", newJsonStub);
+            // Then
+            assertThat(HttpSteps.WIREMOCK_STUBS).containsKey("TEST_GET")
+                    .extractingByKey("TEST_GET")
+                    .isInstanceOf(UUID.class)
+                    .isNotEqualTo(oldStubId);
+            assertThat(HttpSteps.MOCKED_PATHS)
+                    .contains("https://backend") // We don't remove the old path: it could be used by another mock
+                    .contains("http://backend");
+            assertThat(HttpSteps.wireMockServer.getStubMapping(oldStubId).isPresent()).isFalse();
+            assertThat(HttpSteps.wireMockServer.getStubMapping(HttpSteps.WIREMOCK_STUBS.get("TEST_GET")).isPresent()).isTrue();
         }
     }
 

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -7,7 +7,7 @@ Feature: to interact with an http service and setup mocks
     {
       "request": {
         "method": "GET",
-        "url": "/backend/pet"
+        "url": "http://backend/pet"
       },
       "response": {
         "status": 200,
@@ -40,9 +40,21 @@ Feature: to interact with an http service and setup mocks
       | https    |
 
   Scenario Outline: We can use WireMock json stubbing and call it
-    Given the <protocol> wiremock with id "test":
+    Given the wiremock with id "test":
     """
-    {{{wiremock_spec_json}}}
+    {
+      "request": {
+        "method": "GET",
+        "url": "<protocol>://backend/pet"
+      },
+      "response": {
+        "status": 200,
+        "body": "Hello pet",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
     """
     When we get on "<protocol>://backend/pet"
     Then we received a status OK_200 and:
@@ -72,7 +84,7 @@ Feature: to interact with an http service and setup mocks
     {
       "request": {
         "method": "GET",
-        "url": "/backend/pet/{{value}}"
+        "url": "http://backend/pet/{{value}}"
       },
       "response": {
         "status": 200,
@@ -95,7 +107,7 @@ Feature: to interact with an http service and setup mocks
     {
       "request": {
         "method": "GET",
-        "urlPattern": "/backend/pet\\?name=(.*)"
+        "urlPattern": "http://backend/pet\\?name=(.*)"
       },
       "response": {
         "status": 200,
@@ -124,12 +136,12 @@ Feature: to interact with an http service and setup mocks
     Hello pet
     """
     #We can edit the mock later using its id
-    Then when the https wiremock with id "GET_PET" is:
+    Then when the wiremock with id "GET_PET" is:
     """
     {
       "request": {
         "method": "POST",
-        "urlPathTemplate": "backend/pet/{animal}",
+        "urlPathTemplate": "https://backend/pet/{animal}",
         "pathParameters": {
           "animal" : {
             "matches": "dog|cat"

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -2,6 +2,22 @@ Feature: to interact with an http service and setup mocks
 
   Background:
     Given we listen for incoming request on a test-specific socket
+    Given that wiremock_spec_json is:
+    """
+    {
+      "request": {
+        "method": "GET",
+        "url": "/backend/pet"
+      },
+      "response": {
+        "status": 200,
+        "body": "Hello pet",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+    """
 
   Scenario Outline: we can setup a mock and call it
     Given that calling "<protocol>://backend/hello" will return:
@@ -22,6 +38,136 @@ Feature: to interact with an http service and setup mocks
       | protocol |
       | http     |
       | https    |
+
+  Scenario Outline: We can use WireMock json subbing and call it
+    Given the following <protocol> wiremock with id "test":
+    """
+    {{{wiremock_spec_json}}}
+    """
+    When we get on "<protocol>://backend/pet"
+    Then we received a status OK_200 and:
+    """
+    Hello pet
+    """
+    Examples:
+      | protocol |
+      | https    |
+      | http     |
+
+  Scenario: The default protocol for wiremock is http
+    Given the following wiremock with id "test":
+    """
+    {{{wiremock_spec_json}}}
+    """
+    When we get on "http://backend/pet"
+    Then we received a status OK_200 and:
+    """
+    Hello pet
+    """
+
+  Scenario: we can use the cucumber context in our mock
+    Given that value is "dog"
+    Given the following wiremock:
+    """
+    {
+      "request": {
+        "method": "GET",
+        "url": "/backend/pet/{{value}}"
+      },
+      "response": {
+        "status": 200,
+        "body": "Hello {{value}}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+    """
+    When we get on "http://backend/pet/dog"
+    Then we received a status OK_200 and:
+    """
+    Hello dog
+    """
+
+  Scenario: we can use the WireMock handlebar utils in our mock
+    Given the following wiremock:
+    """
+    {
+      "request": {
+        "method": "GET",
+        "urlPattern": "/backend/pet\\?name=(.*)"
+      },
+      "response": {
+        "status": 200,
+        "body": "Hello \{{request.query.name}}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+    """
+    When we get on "http://backend/pet?name=dog"
+    Then we received a status OK_200 and:
+    """
+    Hello dog
+    """
+
+  Scenario: we can give an id to a wiremock to edit it later
+    # We set a mock with an id to be able to edit it later
+    Given the following wiremock with id "GET_PET":
+    """
+    {{{wiremock_spec_json}}}
+    """
+    When we get on "http://backend/pet"
+    Then we received a status OK_200 and:
+    """
+    Hello pet
+    """
+    #We can edit the mock later using its id
+    When we edit the wiremock with id "GET_PET" to https:
+    """
+    {
+      "request": {
+        "method": "POST",
+        "url": "backend/pet/dog"
+      },
+      "response": {
+        "status": 500,
+        "body": "New doggo creation failed",
+        "headers": {
+          "Content-Type": "application/text"
+        }
+      }
+    }
+    """
+    When we POST on "https://backend/pet/dog"
+    Then we received a status INTERNAL_SERVER_ERROR_500 and:
+    """
+    New doggo creation failed
+    """
+    And _response.headers.Content-Type == "application/text"
+
+    Given that we allow unhandled mocked requests
+    Then when we get on "http://backend/pet"
+    Then we received a status NOT_FOUND_404
+    And _response.body.payload == "?contains Request was not matched"
+    And _response.body.payload == "?contains URL does not match"
+    And _response.body.payload == "?contains HTTP method does not match"
+
+  Scenario: we can remove a mock with its id
+    Given the following wiremock with id "GET_PET":
+    """
+    {{{wiremock_spec_json}}}
+    """
+    When we get on "http://backend/pet"
+    Then we received a status OK_200 and:
+    """
+    Hello pet
+    """
+    When we remove the wiremock with id "GET_PET"
+    Given that we allow unhandled mocked requests
+    Then when we get on "http://backend/pet"
+    Then we received a status NOT_FOUND_404
 
   Scenario: we provide steps to assert an http response
     Given that calling "http://backend/hello" will return a status 200 and "Hello"

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -39,7 +39,7 @@ Feature: to interact with an http service and setup mocks
       | http     |
       | https    |
 
-  Scenario Outline: We can use WireMock json subbing and call it
+  Scenario Outline: We can use WireMock json stubbing and call it
     Given the following <protocol> wiremock with id "test":
     """
     {{{wiremock_spec_json}}}
@@ -89,7 +89,7 @@ Feature: to interact with an http service and setup mocks
     Hello dog
     """
 
-  Scenario: we can use the WireMock handlebar utils in our mock
+  Scenario: we can use the WireMock Handlebars utils in our mock
     Given the following wiremock:
     """
     {

--- a/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
+++ b/tzatziki-http/src/test/resources/com/decathlon/tzatziki/steps/http.feature
@@ -40,7 +40,7 @@ Feature: to interact with an http service and setup mocks
       | https    |
 
   Scenario Outline: We can use WireMock json stubbing and call it
-    Given the following <protocol> wiremock with id "test":
+    Given the <protocol> wiremock with id "test":
     """
     {{{wiremock_spec_json}}}
     """
@@ -55,7 +55,7 @@ Feature: to interact with an http service and setup mocks
       | http     |
 
   Scenario: The default protocol for wiremock is http
-    Given the following wiremock with id "test":
+    Given the wiremock with id "test":
     """
     {{{wiremock_spec_json}}}
     """
@@ -67,7 +67,7 @@ Feature: to interact with an http service and setup mocks
 
   Scenario: we can use the cucumber context in our mock
     Given that value is "dog"
-    Given the following wiremock:
+    Given the wiremock:
     """
     {
       "request": {
@@ -90,7 +90,7 @@ Feature: to interact with an http service and setup mocks
     """
 
   Scenario: we can use the WireMock Handlebars utils in our mock
-    Given the following wiremock:
+    Given the wiremock:
     """
     {
       "request": {
@@ -114,7 +114,7 @@ Feature: to interact with an http service and setup mocks
 
   Scenario: we can give an id to a wiremock to edit it later
     # We set a mock with an id to be able to edit it later
-    Given the following wiremock with id "GET_PET":
+    Given that the wiremock with id "GET_PET" is:
     """
     {{{wiremock_spec_json}}}
     """
@@ -124,16 +124,21 @@ Feature: to interact with an http service and setup mocks
     Hello pet
     """
     #We can edit the mock later using its id
-    When we edit the wiremock with id "GET_PET" to https:
+    Then when the https wiremock with id "GET_PET" is:
     """
     {
       "request": {
         "method": "POST",
-        "url": "backend/pet/dog"
+        "urlPathTemplate": "backend/pet/{animal}",
+        "pathParameters": {
+          "animal" : {
+            "matches": "dog|cat"
+          }
+        }
       },
       "response": {
-        "status": 500,
-        "body": "New doggo creation failed",
+        "status": 201,
+        "body": "New doggo created",
         "headers": {
           "Content-Type": "application/text"
         }
@@ -141,9 +146,9 @@ Feature: to interact with an http service and setup mocks
     }
     """
     When we POST on "https://backend/pet/dog"
-    Then we received a status INTERNAL_SERVER_ERROR_500 and:
+    Then we received a status CREATED_201 and:
     """
-    New doggo creation failed
+    New doggo created
     """
     And _response.headers.Content-Type == "application/text"
 
@@ -153,20 +158,9 @@ Feature: to interact with an http service and setup mocks
     And _response.body.payload == "?contains Request was not matched"
     And _response.body.payload == "?contains URL does not match"
     And _response.body.payload == "?contains HTTP method does not match"
-
-  Scenario: we can remove a mock with its id
-    Given the following wiremock with id "GET_PET":
-    """
-    {{{wiremock_spec_json}}}
-    """
-    When we get on "http://backend/pet"
-    Then we received a status OK_200 and:
-    """
-    Hello pet
-    """
-    When we remove the wiremock with id "GET_PET"
-    Given that we allow unhandled mocked requests
-    Then when we get on "http://backend/pet"
+    Then when we GET on "https://backend/pet"
+    Then we received a status NOT_FOUND_404
+    Then when we POST on "https://backend/pet/fish"
     Then we received a status NOT_FOUND_404
 
   Scenario: we provide steps to assert an http response


### PR DESCRIPTION
Add support for defining, editing, and removing WireMock stubs using native JSON stub mapping format directly in Tzatziki HTTP steps. 

**WireMock JSON Stubbing Support:**

* Added 2 new step definitions in `HttpSteps.java` to allow users to set up and edit WireMock stubs using JSON, including support for assigning IDs to stubs for later modification or removal.
* Implemented protocol selection (http/https) with http as default and template variable support in stub definitions, and ensured all stub URLs are remapped to Tzatziki's internal scheme for isolation. [[1]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bR633-R688) [[2]](diffhunk://#diff-c5ec29abea6cd81fea2ec6c1acb26db2eca2166e5a0811f33e44d6a2dc57fc93R100-R135)

**Utility Enhancements:**

* Introduced `remapUrlOfStubMapping` in `HttpWiremockUtils.java` to rewrite WireMock stub URLs to the internal `_mocked/<protocol>/<host>` format, preserving match semantics and logging warnings for unsupported cases.
* Added a utility method to remove mocked paths from the tracked set when a stub is deleted.

**Documentation and Testing:**

* Updated `README.md` with comprehensive documentation and usage examples for the new WireMock JSON stubbing steps, including protocol selection, stub IDs, editing/removal, template variables, and Handlebars helpers.
* Enhanced feature test `http.feature` to include an example of setting up a WireMock stub with JSON.

**Internal Consistency and Refactoring:**

* Replaced hardcoded `"_response"` string with a constant (`OBJECT_STEPS_RESPONSE_KEY`) throughout `HttpSteps.java` for better maintainability. [[1]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bL230-R234) [[2]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bL239-R243) [[3]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bL309-R313) [[4]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bL319-R323) [[5]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bL371-R375) [[6]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bL592-R596)
* Added necessary imports and logging support to facilitate new features and debugging. [[1]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bR19) [[2]](diffhunk://#diff-9eadedd293cc37553d6e65d2d2380e81e7e5ee397fdce57ea71eeb02ae6a760bR31) [[3]](diffhunk://#diff-c5ec29abea6cd81fea2ec6c1acb26db2eca2166e5a0811f33e44d6a2dc57fc93R4-R12) [[4]](diffhunk://#diff-c5ec29abea6cd81fea2ec6c1acb26db2eca2166e5a0811f33e44d6a2dc57fc93R22-R30)

These changes provide a powerful and flexible way to manage HTTP mocks in Tzatziki, leveraging WireMock's advanced capabilities while maintaining test isolation and ease of use.