### PR TITLE
fix: use 'published' type in release.yml on v4 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: release a new version to maven central
 
 on:
   release:
-    types:
-      - released
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
The v4 branch's release.yml still used `types: [released]`, which never fires for prereleases. This is why the v4.0.0-beta prerelease didn't trigger the Maven Central release workflow — GitHub Actions evaluates the `release` event trigger using the workflow file at the tagged commit, not the default branch. Aligns v4 with the fix already on main (#877).