### PR TITLE
feat: Configure Lombok's @Builder to use the initial value defined in the f…

### DIFF
--- a/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/Interaction.java
+++ b/tzatziki-http/src/main/java/com/decathlon/tzatziki/utils/Interaction.java
@@ -183,6 +183,7 @@ public class Interaction {
         @Builder.Default
         public Body body = new Body();
         public String status;
+        @Builder.Default
         public int consumptions = 1;
         public long delay;
         public long time;


### PR DESCRIPTION
Configure Lombok's @Builder to use the initial value defined in the field declaration for Interaction.Response.consumption, using @Builder.Default annotation on the field.